### PR TITLE
basic proxy-wasm module support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ wasm-objs :=  third-party/wasm3/source/m3_api_libc.o \
 			  hashtable.o \
 			  runtime.o \
 			  worker_thread.o \
-			  opa.o
+			  opa.o \
+			  proxywasm.o
 
 # Set the path to the Kernel build utils.
 KBUILD=/lib/modules/$(shell uname -r)/build/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXTRA_CFLAGS := -foptimize-sibling-calls \
 				-I$(PWD)/third-party/wasm3/source/ \
 				-I$(PWD)/third-party/base64 \
 				-I$(PWD)/third-party/parson \
-				#-Dd_m3LogCompile=1
+				-Dd_m3LogCompile=1
 
 # Enable floating point arithmetic
 ARCH := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXTRA_CFLAGS := -foptimize-sibling-calls \
 				-I$(PWD)/third-party/wasm3/source/ \
 				-I$(PWD)/third-party/base64 \
 				-I$(PWD)/third-party/parson \
-				-Dd_m3LogCompile=1
+				# -Dd_m3LogCompile=1
 
 # Enable floating point arithmetic
 ARCH := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXTRA_CFLAGS := -foptimize-sibling-calls \
 				-I$(PWD)/third-party/wasm3/source/ \
 				-I$(PWD)/third-party/base64 \
 				-I$(PWD)/third-party/parson \
-				# -Dd_m3LogCompile=1
+				#-Dd_m3LogCompile=1
 
 # Enable floating point arithmetic
 ARCH := $(shell uname -m)

--- a/device_driver.c
+++ b/device_driver.c
@@ -125,6 +125,8 @@ static wasm_vm_result load_module(char *name, char *code, unsigned length, char 
             return result;
         }
 
+        wasm_vm_module *module = result.data->module;
+
         if (entrypoint)
         {
             printk("wasm: calling module entrypoint: %s", entrypoint);
@@ -134,7 +136,7 @@ static wasm_vm_result load_module(char *name, char *code, unsigned length, char 
             if (result.err &&
               !(result.err = m3Err_functionLookupFailed && strcmp(entrypoint, DEFAULT_MODULE_ENTRYPOINT) == 0))
             {
-                FATAL("wasm_vm_call: %s", result.err);
+                FATAL("wasm_vm_call: %s error: %s", result.err, wasm_vm_last_error(vm));
                 wasm_vm_unlock(vm);
                 return result;
             }
@@ -144,7 +146,7 @@ static wasm_vm_result load_module(char *name, char *code, unsigned length, char 
 
         if (strcmp(name, OPA_MODULE) == 0)
         {
-            result = init_opa_for(vm);
+            result = init_opa_for(vm, module);
             if (result.err)
             {
                 FATAL("init_opa_for: %s", result.err);
@@ -154,7 +156,7 @@ static wasm_vm_result load_module(char *name, char *code, unsigned length, char 
         }
         else if (strstr(name, "proxywasm") != NULL)
         {
-            result = init_proxywasm_for(vm, name);
+            result = init_proxywasm_for(vm, module);
             if (result.err)
             {
                 FATAL("init_proxywasm_for: %s", result.err);

--- a/device_driver.c
+++ b/device_driver.c
@@ -14,6 +14,7 @@
 #include "device_driver.h"
 #include "json.h"
 #include "opa.h"
+#include "proxywasm.h"
 #include "runtime.h"
 
 /* Global variables are declared as static, so are global within the file. */
@@ -147,6 +148,16 @@ static wasm_vm_result load_module(char *name, char *code, unsigned length, char 
             if (result.err)
             {
                 FATAL("init_opa_for: %s", result.err);
+                wasm_vm_unlock(vm);
+                return result;
+            }
+        }
+        else if (strstr(name, "proxywasm") != NULL)
+        {
+            result = init_proxywasm_for(vm, name);
+            if (result.err)
+            {
+                FATAL("init_proxywasm_for: %s", result.err);
                 wasm_vm_unlock(vm);
                 return result;
             }

--- a/device_driver.c
+++ b/device_driver.c
@@ -231,6 +231,37 @@ static int device_release(struct inode *inode, struct file *file)
                 goto cleanup;
             }
         }
+        else if (strcmp("proxywasm_test", command) == 0)
+        {
+            // TODO test only
+            // Create a new non-root context
+            proxywasm *proxywasm = this_cpu_proxywasm();
+
+            wasm_vm_result result = proxywasm_create_context(proxywasm);
+            if (result.err)
+            {
+                FATAL("proxywasm_create_context for module failed: %s", result.err)
+                goto cleanup;
+            }
+
+            printk("wasm: proxy_on_context_create result %d", result.data->i32);
+
+            result = proxy_on_new_connection(proxywasm);
+            if (result.err)
+            {
+                FATAL("proxy_on_new_connection for module failed: %s", result.err)
+                goto cleanup;
+            }
+
+            printk("wasm: proxy_on_new_connection result %d", result.data->i32);
+
+            result = proxy_on_downstream_data(proxywasm, 128, false);
+            if (result.err)
+            {
+                FATAL("proxy_on_downstream_data for module failed: %s",result.err)
+                goto cleanup;
+            }
+        }
         else
         {
             printk(KERN_ERR "wasm: command not implemented: %s", command);

--- a/device_driver.c
+++ b/device_driver.c
@@ -141,6 +141,8 @@ static wasm_vm_result load_module(char *name, char *code, unsigned length, char 
                 return result;
             }
 
+            printk("wasm: module entrypoint finished");
+
             result.err = NULL;
         }
 

--- a/hashtable.c
+++ b/hashtable.c
@@ -16,8 +16,8 @@
 
 struct h_node
 {
-    void *data;
     int key;
+    void *data;
     int data_length;
     struct hlist_node node;
 };

--- a/netfilter.c
+++ b/netfilter.c
@@ -42,13 +42,18 @@ unsigned int hook_func_out(void *priv, struct sk_buff *skb, const struct nf_hook
         goto accept;
     }
 
-    wasm_vm_module *module = wasm_vm_get_module(vm, DNS_MODULE);
-    if (!module)
+    wasm_vm_result result = wasm_vm_get_module(vm, DNS_MODULE); // TODO this we could use a module cache here, this is an expensive lookup
+    if (result.err)
+    {
+        FATAL("netfilter wasm_vm_get_module error: %s", result.err);
+        goto accept;
+    }
+    if (!result.data->module)
     {
         goto accept;
     }
 
-    wasm_vm_result result = wasm_vm_malloc(vm, DNS_MODULE, packetLen);
+    result = wasm_vm_malloc(vm, DNS_MODULE, packetLen);
     if (result.err)
     {
         FATAL("netfilter wasm_vm_malloc error: %s", result.err);
@@ -60,7 +65,7 @@ unsigned int hook_func_out(void *priv, struct sk_buff *skb, const struct nf_hook
     char *wasmPacketPtr = mem + wasmPacket;
     memcpy(wasmPacketPtr, packetData, packetLen);
 
-    result = wasm_vm_call(vm,
+    result = wasm_vm_call(vm, // TODO this we could use a function cache here, this is an expensive lookup
                           DNS_MODULE,
                           "packet_out",
                           wasmPacket,
@@ -100,13 +105,18 @@ unsigned int hook_func_in(void *priv, struct sk_buff *skb, const struct nf_hook_
         goto accept;
     }
 
-    wasm_vm_module *module = wasm_vm_get_module(vm, DNS_MODULE);
-    if (!module)
+    wasm_vm_result result = wasm_vm_get_module(vm, DNS_MODULE); // TODO this we could use a module cache here, this is an expensive lookup
+    if (result.err)
+    {
+        FATAL("netfilter wasm_vm_get_module error: %s", result.err);
+        goto accept;
+    }
+    if (!result.data->module)
     {
         goto accept;
     }
 
-    wasm_vm_result result = wasm_vm_malloc(vm, DNS_MODULE, packetLen);
+    result = wasm_vm_malloc(vm, DNS_MODULE, packetLen);
     if (result.err)
     {
         FATAL("netfilter wasm_vm_malloc error: %s", result.err);

--- a/opa.c
+++ b/opa.c
@@ -10,7 +10,6 @@
 
 #include "opa.h"
 #include "json.h"
-#include "runtime.h"
 
 typedef struct opa_wrapper
 {

--- a/opa.c
+++ b/opa.c
@@ -152,9 +152,9 @@ static wasm_vm_result link_opa_builtins(opa_wrapper *opa, wasm_vm_module *module
 
     const char *env = "env";
 
-    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "opa_abort", "(i)", &opa_abort, opa)));
-    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "opa_println", "(i)", &opa_println, opa)));
-    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "opa_builtin0", "i(ii)", &opa_builtin0, opa)));
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "opa_abort", "(i)", opa_abort, opa)));
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "opa_println", "(i)", opa_println, opa)));
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "opa_builtin0", "i(ii)", opa_builtin0, opa)));
 
 _catch:
     return (wasm_vm_result){.err = result};

--- a/opa.h
+++ b/opa.h
@@ -15,7 +15,7 @@
 
 #define OPA_MODULE "opa"
 
-wasm_vm_result init_opa_for(wasm_vm *vm);
+wasm_vm_result init_opa_for(wasm_vm *vm, wasm_vm_module *module);
 
 int this_cpu_opa_eval(const char *input);
 

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -85,7 +85,8 @@ static wasm_vm_result link_proxywasm_hostfunctions(proxywasm *proxywasm, wasm_vm
 
     const char *env = "env";
 
-    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_log", "i(iii)", &proxy_log, proxywasm)));
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_log", "i(iii)", proxy_log, proxywasm)));
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_set_tick_period_milliseconds", "i(i)", proxy_set_tick_period_milliseconds, proxywasm)));
 
 _catch:
     return (wasm_vm_result){.err = result};

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -302,7 +302,8 @@ void set_property_v(proxywasm_context *p, const char *key, const void *value, co
 
     strcpy(path, key);
 
-    for (int i = 0; i < path_len; i++)
+    int i;
+    for (i = 0; i < path_len; i++)
     {
         if (path[i] == '.')
             path[i] = 0;

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ * 
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied, 
+ * modified, or distributed except according to those terms.
+ */
+
+#include "proxywasm.h"
+
+typedef struct proxywasm
+{
+    wasm_vm *vm;
+	// Memory management
+    wasm_vm_function *proxy_on_memory_allocate;
+    // Module lifecycle
+    wasm_vm_function *proxy_on_context_create;
+    wasm_vm_function *proxy_on_done;
+    wasm_vm_function *proxy_on_log;
+    wasm_vm_function *proxy_on_delete;
+    // Configuration
+    wasm_vm_function *proxy_on_vm_start;
+    wasm_vm_function *proxy_on_configure;
+    // Timers
+    wasm_vm_function *proxy_on_tick;
+    // TCP/UDP/QUIC stream (L4) extensions
+    wasm_vm_function *proxy_on_new_connection;
+    wasm_vm_function *proxy_on_downstream_data;
+    wasm_vm_function *proxy_on_downstream_close;
+    wasm_vm_function *proxy_on_upstream_data;
+    wasm_vm_function *proxy_on_upstream_close;    
+} proxywasm;
+
+static proxywasm *proxywasms[NR_CPUS] = {0};
+
+wasm_vm_result proxy_on_memory_allocate(proxywasm *proxywasm, i32 size)
+{
+    return wasm_vm_call_direct(opa->vm, opa->proxy_on_memory_allocate, size);
+}
+
+proxywasm* this_cpu_proxywasm(void)
+{
+    int cpu = get_cpu();
+    put_cpu();
+    return proxywasms[cpu];
+}
+
+m3ApiRawFunction(proxy_log)
+{
+    m3ApiReturnType (i32)
+
+    m3ApiGetArg(i32, log_level);
+    m3ApiGetArgMem(char *, message_data);
+    m3ApiGetArg(i32, message_size);
+
+    m3ApiCheckMem(message_data, message_size);
+
+    printk("proxywasm: [%d] %.*s", log_level, message_size, message_data);
+
+    m3ApiSuccess();
+}
+
+m3ApiRawFunction(proxy_set_tick_period_milliseconds)
+{
+    m3ApiReturnType(i32);
+
+    m3ApiGetArg(i32, tick_period);
+
+    proxywasm *proxywasm = (proxywasm*) _ctx->userdata;
+
+    printk("wasm: calling proxy_set_tick_period_milliseconds %d", builtin_id);
+
+    proxywasm->tick_period = tick_period;
+
+    m3ApiReturn(1);
+}
+
+static wasm_vm_result link_proxywasm_builtins(proxywasm *proxywasm, wasm_vm_module *module)
+{
+    M3Result result = m3Err_none;
+
+    const char *env = "env";
+
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_log", "i(iii)", &proxy_log, proxywasm)));
+
+_catch:
+    return (wasm_vm_result){.err = result};
+}
+
+wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module)
+{
+    proxywasm *proxywasm = kmalloc(sizeof(proxywasm), GFP_KERNEL);
+    proxywasm->proxy_on_memory_allocate = wasm_vm_get_function(vm, module, "proxy_on_memory_allocate");
+    proxywasm->proxy_on_context_create = wasm_vm_get_function(vm, module, "proxy_on_context_create");
+    proxywasm->proxy_on_vm_start = wasm_vm_get_function(vm, module, "proxy_on_vm_start");
+    proxywasm->proxy_on_configure = wasm_vm_get_function(vm, module, "proxy_on_configure");
+    proxywasm->vm = vm;
+
+    wasm_vm_result result = wasm_vm_call_direct(vm, proxywasm->proxy_on_context_create);
+    if (result.err)
+    {
+        kfree(proxywasm);
+        return result;
+    }
+
+    result = wasm_vm_call_direct(vm, opa->json_dump, result.data->i32);
+    if (result.err)
+    {
+        kfree(opa);
+        return result;
+    }
+
+    uint8_t *memory = wasm_vm_memory(vm);
+    i32 builtinsJson = result.data->i32;
+
+    // parse and link
+    char *builtins = memory + builtinsJson;
+    if (parse_opa_builtins(opa, builtins) > 0)
+    {
+        result = link_proxywasm_builtins(opa, wasm_vm_get_module(vm, OPA_MODULE));
+        if (result.err)
+        {
+            kfree(opa->builtins);
+            kfree(opa);
+            return result;
+        }
+    }
+
+    opa_free(opa, builtinsJson);
+
+    opas[vm->cpu] = opa;
+
+    return (wasm_vm_result){.err = NULL};
+}
+
+wasm_vm_result opa_eval(proxywasm *proxywasm, i32 inputAddr, i32 inputLen)
+{
+    i32 entrypoint = 0;
+    i32 dataAddr = 0;
+    i32 heapAddr = 0;
+    i32 format = 0;
+
+    return wasm_vm_call_direct(proxywasm->vm, opa->eval, 0, entrypoint, dataAddr, inputAddr, inputLen, heapAddr, format);
+}

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -295,24 +295,20 @@ _catch:
     return (wasm_vm_result){.err = result};
 }
 
-void set_property_v(proxywasm_context *p, const char *value, const int value_len, ...)
+void set_property_v(proxywasm_context *p, const char *key, const void *value, const int value_len)
 {
     char path[256];
-    int path_len = 0;
+    int path_len = strlen(key);
 
-    va_list ap;
-    va_start(ap, value_len);
-    char *part = NULL;
-    while ((part = va_arg(ap, char *)) != NULL)
+    strcpy(path, key);
+
+    for (int i = 0; i < path_len; i++)
     {
-        int len = strlen(part);
-        memcpy(path + path_len, part, len);
-        path_len += len + 1;
-        path[path_len] = 0;
+        if (path[i] == '.')
+            path[i] = 0;
     }
-    va_end(ap);
 
-    set_property(p, path, path_len - 1, value, value_len);
+    set_property(p, path, path_len, value, value_len);
 }
 
 void print_property_key(const char *func, const char *key, int key_len)
@@ -372,20 +368,20 @@ error:
         // TODO: this is only test data
         char empty_map[] = {0, 0, 0, 0};
         u64 listener_direction = ListenerDirectionInbound;
-        set_property_v(root_context, "lima", strlen("lima"), "node", "id", NULL);
-        set_property_v(root_context, "catalog-v1-6578575465-lz5h2", strlen("catalog-v1-6578575465-lz5h2"), "node", "metadata", "NAME", NULL);
-        set_property_v(root_context, "kube-system", strlen("kube-system"), "node", "metadata", "NAMESPACE", NULL);
-        set_property_v(root_context, "blade-runner", strlen("blade-runner"), "node", "metadata", "OWNER", NULL);
-        set_property_v(root_context, "joska", strlen("joska"), "node", "metadata", "WORKLOAD_NAME", NULL);
-        set_property_v(root_context, "1.13.5", strlen("1.13.5"), "node", "metadata", "ISTIO_VERSION", NULL);
-        set_property_v(root_context, "mesh1", strlen("mesh1"), "node", "metadata", "MESH_ID", NULL);
-        set_property_v(root_context, "cluster1", strlen("cluster1"), "node", "metadata", "CLUSTER_ID", NULL);
-        set_property_v(root_context, empty_map, sizeof(empty_map), "node", "metadata", "LABELS", NULL);
-        set_property_v(root_context, empty_map, sizeof(empty_map), "node", "metadata", "PLATFORM_METADATA", NULL);
-        set_property_v(root_context, "catalog", strlen("catalog"), "node", "metadata", "APP_CONTAINERS", NULL);
-        set_property_v(root_context, "10.20.160.34,fe80::84cb:9eff:feb7:941b", strlen("10.20.160.34,fe80::84cb:9eff:feb7:941b"), "node", "metadata", "INSTANCE_IPS", NULL);
-        set_property_v(root_context, (char *)&listener_direction, sizeof(listener_direction), "listener_direction", NULL);
-        set_property_v(root_context, "0", strlen("0"), "plugin_root_id", NULL);
+        set_property_v(root_context, "node.id", "lima", strlen("lima"));
+        set_property_v(root_context, "node.metadata.NAME", "catalog-v1-6578575465-lz5h2", strlen("catalog-v1-6578575465-lz5h2"));
+        set_property_v(root_context, "node.metadata.NAMESPACE", "kube-system", strlen("kube-system"));
+        set_property_v(root_context, "node.metadata.OWNER", "blade-runner", strlen("blade-runner"));
+        set_property_v(root_context, "node.metadata.WORKLOAD_NAME", "joska", strlen("joska"));
+        set_property_v(root_context, "node.metadata.ISTIO_VERSION", "1.13.5", strlen("1.13.5"));
+        set_property_v(root_context, "node.metadata.MESH_ID", "mesh1", strlen("mesh1"));
+        set_property_v(root_context, "node.metadata.CLUSTER_ID", "cluster1", strlen("cluster1"));
+        set_property_v(root_context, "node.metadata.LABELS", empty_map, sizeof(empty_map));
+        set_property_v(root_context, "node.metadata.PLATFORM_METADATA", empty_map, sizeof(empty_map));
+        set_property_v(root_context, "node.metadata.APP_CONTAINERS", "catalog", strlen("catalog"));
+        set_property_v(root_context, "node.metadata.INSTANCE_IPS", "10.20.160.34,fe80::84cb:9eff:feb7:941b", strlen("10.20.160.34,fe80::84cb:9eff:feb7:941b"));
+        set_property_v(root_context, "listener_direction", (char *)&listener_direction, sizeof(listener_direction));
+        set_property_v(root_context, "plugin_root_id", "0", strlen("0"));
     }
 
     // Create the root context

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -163,7 +163,7 @@ m3ApiRawFunction(proxy_get_buffer_bytes)
     m3ApiGetArg(i32, offset);
     m3ApiGetArg(i32, max_size);
 
-    m3ApiGetArgMem(char *, return_buffer_data);
+    m3ApiGetArgMem(i32 *, return_buffer_data);
     m3ApiGetArgMem(i32 *, return_buffer_size);
 
     proxywasm *proxywasm = _ctx->userdata;
@@ -183,7 +183,7 @@ m3ApiRawFunction(proxy_get_buffer_bytes)
             return m3Err_mallocFailed;
         }
 
-        printk("wasm: proxy_on_memory_allocate returned %d, value points to %p, *return_buffer_data -> %d", result.data->i32, value, *return_buffer_data);
+        printk("wasm: proxy_on_memory_allocate returned %d, value points to %p, size -> %d", result.data->i32, value, value_len);
 
         int wasm_ptr = result.data->i32;
 
@@ -193,7 +193,7 @@ m3ApiRawFunction(proxy_get_buffer_bytes)
         *return_buffer_data = wasm_ptr;
         *return_buffer_size = value_len;
 
-        printk("wasm: get_buffer_bytes ready, value_len: %d, return_buffer_data -> %d value %d", value_len, *return_buffer_data, *(u32*)value_ptr);
+        printk("wasm: get_buffer_bytes ready, value_len: %d, return_buffer_data -> %d", value_len, *return_buffer_data);
 
         m3ApiReturn(WasmResult_Ok);
     }
@@ -424,7 +424,7 @@ void get_property(proxywasm *proxywasm, const char *key, int key_len, char **val
     *value_len = temp->value_len;
 }
 
-u32 magic_number = 1025705063;
+u32 magic_number = htonl(1025705063);
 
 void get_buffer_bytes(proxywasm *proxywasm, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len)
 {

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -114,8 +114,6 @@ m3ApiRawFunction(proxy_get_property)
 
     get_property(proxywasm, property_path_data, property_path_size, &value, &value_len);
 
-    printk("get_property ready, value_len: %d", value_len);
-
     if (value_len > 0)
     {
         wasm_vm_result result = proxy_on_memory_allocate(proxywasm, value_len);
@@ -131,10 +129,12 @@ m3ApiRawFunction(proxy_get_property)
         *return_property_value_size = value_len;
         memcpy(value, value, value_len);
 
+        printk("wasm: proxy_get_property ready, value_len: %d", value_len);
+
         m3ApiReturn(WasmResult_Ok);
     }
 
-    //m3ApiReturn(result);
+    printk("wasm: proxy_get_property WasmResult_NotFound");
     m3ApiReturn(WasmResult_NotFound);
 }
 
@@ -292,7 +292,11 @@ void get_property(proxywasm *proxywasm, const char *key, int key_len, char **val
 
     hash_for_each_possible(proxywasm->properties, cur, node, key_i)
     {
-        temp = cur;
+        if (cur->key_len == key_len && memcmp(cur->key, key, key_len) == 0)
+        {
+            temp = cur;
+            break;
+        }
     }
 
     if (!temp)

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -216,8 +216,8 @@ wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module)
         set_property_v(proxywasm, "1.13.5", strlen("1.13.5"), "node", "metadata", "ISTIO_VERSION", NULL);
         set_property_v(proxywasm, "mesh1", strlen("mesh1"), "node", "metadata", "MESH_ID", NULL);
         set_property_v(proxywasm, "cluster1", strlen("cluster1"), "node", "metadata", "CLUSTER_ID", NULL);
-        set_property_v(proxywasm, empty_map, 4, "node", "metadata", "LABELS", NULL);
-        set_property_v(proxywasm, empty_map, 4, "node", "metadata", "PLATFORM_METADATA", NULL);
+        set_property_v(proxywasm, empty_map, sizeof(empty_map), "node", "metadata", "LABELS", NULL);
+        set_property_v(proxywasm, empty_map, sizeof(empty_map), "node", "metadata", "PLATFORM_METADATA", NULL);
         set_property_v(proxywasm, "catalog", strlen("catalog"), "node", "metadata", "APP_CONTAINERS", NULL);
         set_property_v(proxywasm, "10.20.160.34,fe80::84cb:9eff:feb7:941b", strlen("10.20.160.34,fe80::84cb:9eff:feb7:941b"), "node", "metadata", "INSTANCE_IPS", NULL);
     }

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -287,7 +287,7 @@ _catch:
     return (wasm_vm_result){.err = result};
 }
 
-void set_property_v(proxywasm *p, const char *value, const int value_len, ...)
+void set_property_v(proxywasm_context *p, const char *value, const int value_len, ...)
 {
     char path[256];
     int path_len = 0;
@@ -304,7 +304,7 @@ void set_property_v(proxywasm *p, const char *value, const int value_len, ...)
     }
     va_end(ap);
 
-    set_property(p->current_context, path, path_len - 1, value, value_len);
+    set_property(p, path, path_len - 1, value, value_len);
 }
 
 void print_property_key(const char *func, const char *key, int key_len)
@@ -350,19 +350,19 @@ wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char *module)
         // TODO: this is only test data
         char empty_map[] = {0, 0, 0, 0};
         u64 listener_direction = ListenerDirectionInbound;
-        set_property_v(proxywasm, "lima", strlen("lima"), "node", "id", NULL);
-        set_property_v(proxywasm, "catalog-v1-6578575465-lz5h2", strlen("catalog-v1-6578575465-lz5h2"), "node", "metadata", "NAME", NULL);
-        set_property_v(proxywasm, "kube-system", strlen("kube-system"), "node", "metadata", "NAMESPACE", NULL);
-        set_property_v(proxywasm, "blade-runner", strlen("blade-runner"), "node", "metadata", "OWNER", NULL);
-        set_property_v(proxywasm, "joska", strlen("joska"), "node", "metadata", "WORKLOAD_NAME", NULL);
-        set_property_v(proxywasm, "1.13.5", strlen("1.13.5"), "node", "metadata", "ISTIO_VERSION", NULL);
-        set_property_v(proxywasm, "mesh1", strlen("mesh1"), "node", "metadata", "MESH_ID", NULL);
-        set_property_v(proxywasm, "cluster1", strlen("cluster1"), "node", "metadata", "CLUSTER_ID", NULL);
-        set_property_v(proxywasm, empty_map, sizeof(empty_map), "node", "metadata", "LABELS", NULL);
-        set_property_v(proxywasm, empty_map, sizeof(empty_map), "node", "metadata", "PLATFORM_METADATA", NULL);
-        set_property_v(proxywasm, "catalog", strlen("catalog"), "node", "metadata", "APP_CONTAINERS", NULL);
-        set_property_v(proxywasm, "10.20.160.34,fe80::84cb:9eff:feb7:941b", strlen("10.20.160.34,fe80::84cb:9eff:feb7:941b"), "node", "metadata", "INSTANCE_IPS", NULL);
-        set_property_v(proxywasm, (char *)&listener_direction, sizeof(listener_direction), "listener_direction", NULL);
+        set_property_v(root_context, "lima", strlen("lima"), "node", "id", NULL);
+        set_property_v(root_context, "catalog-v1-6578575465-lz5h2", strlen("catalog-v1-6578575465-lz5h2"), "node", "metadata", "NAME", NULL);
+        set_property_v(root_context, "kube-system", strlen("kube-system"), "node", "metadata", "NAMESPACE", NULL);
+        set_property_v(root_context, "blade-runner", strlen("blade-runner"), "node", "metadata", "OWNER", NULL);
+        set_property_v(root_context, "joska", strlen("joska"), "node", "metadata", "WORKLOAD_NAME", NULL);
+        set_property_v(root_context, "1.13.5", strlen("1.13.5"), "node", "metadata", "ISTIO_VERSION", NULL);
+        set_property_v(root_context, "mesh1", strlen("mesh1"), "node", "metadata", "MESH_ID", NULL);
+        set_property_v(root_context, "cluster1", strlen("cluster1"), "node", "metadata", "CLUSTER_ID", NULL);
+        set_property_v(root_context, empty_map, sizeof(empty_map), "node", "metadata", "LABELS", NULL);
+        set_property_v(root_context, empty_map, sizeof(empty_map), "node", "metadata", "PLATFORM_METADATA", NULL);
+        set_property_v(root_context, "catalog", strlen("catalog"), "node", "metadata", "APP_CONTAINERS", NULL);
+        set_property_v(root_context, "10.20.160.34,fe80::84cb:9eff:feb7:941b", strlen("10.20.160.34,fe80::84cb:9eff:feb7:941b"), "node", "metadata", "INSTANCE_IPS", NULL);
+        set_property_v(root_context, (char *)&listener_direction, sizeof(listener_direction), "listener_direction", NULL);
     }
 
     // Create the root context

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -37,7 +37,7 @@ static proxywasm *proxywasms[NR_CPUS] = {0};
 
 wasm_vm_result proxy_on_memory_allocate(proxywasm *proxywasm, i32 size)
 {
-    return wasm_vm_call_direct(opa->vm, opa->proxy_on_memory_allocate, size);
+    return wasm_vm_call_direct(proxywasm->vm, proxywasm->proxy_on_memory_allocate, size);
 }
 
 proxywasm* this_cpu_proxywasm(void)

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -237,8 +237,9 @@ wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module)
         return result;
     }
 
-    i32 root_context_id = 0; // TODO
+    i32 root_context_id = 0;
 
+    // Create the root context
     result = wasm_vm_call_direct(vm, proxywasm->proxy_on_context_create, root_context_id, 0);
     if (result.err)
     {

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -110,9 +110,30 @@ wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module)
         return result;
     }
 
-    result = wasm_vm_call_direct(vm, proxywasm->proxy_on_context_create);
+    i32 root_context_id = 0; // TODO
+
+    result = wasm_vm_call_direct(vm, proxywasm->proxy_on_context_create, root_context_id, 0);
     if (result.err)
     {
+        FATAL("proxy_on_context_create for module %s failed: %s", module, result.err)
+        kfree(proxywasm);
+        return result;
+    }
+
+    result = wasm_vm_call_direct(vm, proxywasm->proxy_on_vm_start, root_context_id, 0);
+    if (result.err)
+    {
+        FATAL("proxy_on_vm_start for module %s failed: %s", module, result.err)
+        kfree(proxywasm);
+        return result;
+    }
+
+    i32 plugin_configuration_size = 0; // TODO
+
+    result = wasm_vm_call_direct(vm, proxywasm->proxy_on_configure, root_context_id, plugin_configuration_size);
+    if (result.err)
+    {
+        FATAL("proxy_on_configure for module %s failed: %s", module, result.err)
         kfree(proxywasm);
         return result;
     }

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -385,13 +385,14 @@ error:
         set_property_v(root_context, "catalog", strlen("catalog"), "node", "metadata", "APP_CONTAINERS", NULL);
         set_property_v(root_context, "10.20.160.34,fe80::84cb:9eff:feb7:941b", strlen("10.20.160.34,fe80::84cb:9eff:feb7:941b"), "node", "metadata", "INSTANCE_IPS", NULL);
         set_property_v(root_context, (char *)&listener_direction, sizeof(listener_direction), "listener_direction", NULL);
+        set_property_v(root_context, "0", strlen("0"), "plugin_root_id", NULL);
     }
 
     // Create the root context
     result = proxy_on_context_create(proxywasm, root_context->id, 0);
     if (result.err)
     {
-        FATAL("proxy_on_context_create for module %s failed: %s", module->name, result.err);
+        FATAL("proxy_on_context_create for module %s failed: %s -> %s", module->name, result.err, wasm_vm_last_error(vm));
         kfree(proxywasm);
         return result;
     }

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -61,7 +61,7 @@ m3ApiRawFunction(proxy_log)
 
     printk("proxywasm: [%d] %.*s", log_level, message_size, message_data);
 
-    m3ApiSuccess();
+    m3ApiReturn(Ok);
 }
 
 m3ApiRawFunction(proxy_set_tick_period_milliseconds)
@@ -79,6 +79,23 @@ m3ApiRawFunction(proxy_set_tick_period_milliseconds)
     m3ApiReturn(Ok);
 }
 
+m3ApiRawFunction(proxy_get_property)
+{
+    m3ApiReturnType(i32);
+
+    m3ApiGetArgMem(char *, property_path_data);
+    m3ApiGetArg(i32, property_path_size);
+
+    m3ApiGetArgMem(char *, return_property_value_data);
+    m3ApiGetArgMem(i32 *, return_property_value_size);
+
+    proxywasm *proxywasm = _ctx->userdata;
+
+    printk("wasm: calling proxy_get_property '%.*s'", property_path_size, property_path_data);
+
+    m3ApiReturn(Ok);
+}
+
 static wasm_vm_result link_proxywasm_hostfunctions(proxywasm *proxywasm, wasm_vm_module *module)
 {
     M3Result result = m3Err_none;
@@ -87,6 +104,7 @@ static wasm_vm_result link_proxywasm_hostfunctions(proxywasm *proxywasm, wasm_vm
 
     _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_log", "i(iii)", proxy_log, proxywasm)));
     _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_set_tick_period_milliseconds", "i(i)", proxy_set_tick_period_milliseconds, proxywasm)));
+    _(SuppressLookupFailure(m3_LinkRawFunctionEx(module, env, "proxy_get_property", "i(iiii)", proxy_get_property, proxywasm)));
 
 _catch:
     return (wasm_vm_result){.err = result};

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -42,6 +42,11 @@ enum WasmResult {
   WasmResult_Unimplemented = 12,
 };
 
+struct proxywasm;
+
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
+
+enum WasmResult get_property(struct proxywasm *proxywasm, const char *key, int key_len, char *value, int *value_len);
+void set_property(struct proxywasm *proxywasm, const char *key, int key_len, const char *value, int value_len);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -57,7 +57,8 @@ struct proxywasm;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
-void get_property(struct proxywasm *proxywasm, const char *key, int key_len, char **value, int *value_len);
-void set_property(struct proxywasm *proxywasm, const char *key, int key_len, const char *value, int value_len);
+void get_property(struct proxywasm *p, const char *key, int key_len, char **value, int *value_len);
+void set_property(struct proxywasm *p, const char *key, int key_len, const char *value, int value_len);
+void get_buffer(struct proxywasm *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len, int *return_flags);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -76,6 +76,10 @@ wasm_vm_result proxy_on_context_create(struct proxywasm *p, i32 context_id, i32 
 wasm_vm_result proxy_on_new_connection(struct proxywasm *p, i32 context_id);
 wasm_vm_result proxy_on_downstream_data(struct proxywasm *p, i32 context_id, i32 data_size, i32 end_of_stream);
 
+// set_property_v is convenience funtion for setting a property on a context, with simple C string paths,
+// the varargs should be path elements followed by a NULL, like: ..., "node", "id", NULL);
+void set_property_v(struct proxywasm_context *p, const char *value, const int value_len, ...);
+
 // host functions, not needed by the API, just forward declerations
 void get_property(struct proxywasm_context *p, const char *key, int key_len, char **value, int *value_len);
 void set_property(struct proxywasm_context *p, const char *key, int key_len, const char *value, int value_len);

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -46,7 +46,7 @@ struct proxywasm;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
-enum WasmResult get_property(struct proxywasm *proxywasm, const char *key, int key_len, char *value, int *value_len);
+void get_property(struct proxywasm *proxywasm, const char *key, int key_len, char **value, int *value_len);
 void set_property(struct proxywasm *proxywasm, const char *key, int key_len, const char *value, int value_len);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -57,6 +57,9 @@ struct proxywasm;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
+wasm_vm_result proxy_on_context_create(struct proxywasm *p, i32 context_id, i32 root_context_id);
+wasm_vm_result proxy_on_new_connection(struct proxywasm *p, i32 context_id);
+
 void get_property(struct proxywasm *p, const char *key, int key_len, char **value, int *value_len);
 void set_property(struct proxywasm *p, const char *key, int key_len, const char *value, int value_len);
 void get_buffer(struct proxywasm *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len, int *return_flags);

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -13,7 +13,7 @@
 
 #include "runtime.h"
 
-enum WasmResult {
+typedef enum {
   WasmResult_Ok = 0,
   // The result could not be found, e.g. a provided key did not appear in a
   // table.
@@ -40,7 +40,18 @@ enum WasmResult {
   WasmResult_BrokenConnection = 11,
   // Feature not implemented.
   WasmResult_Unimplemented = 12,
-};
+} WasmResult;
+
+typedef enum {
+    HttpRequestBody = 0,
+    HttpResponseBody = 1,
+    DownstreamData = 2,
+    UpstreamData = 3,
+    HttpCallResponseBody = 4,
+    GrpcReceiveBuffer = 5,
+    VmConfiguration = 6,
+    PluginConfiguration = 7,
+} BufferType;
 
 struct proxywasm;
 

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -76,8 +76,10 @@ wasm_vm_result proxy_on_context_create(struct proxywasm *p, i32 context_id, i32 
 wasm_vm_result proxy_on_new_connection(struct proxywasm *p, i32 context_id);
 wasm_vm_result proxy_on_downstream_data(struct proxywasm *p, i32 context_id, i32 data_size, i32 end_of_stream);
 
+// host functions, not needed by the API, just forward declerations
 void get_property(struct proxywasm_context *p, const char *key, int key_len, char **value, int *value_len);
 void set_property(struct proxywasm_context *p, const char *key, int key_len, const char *value, int value_len);
-void get_buffer_bytes(struct proxywasm_context *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len);
+void get_buffer_bytes(struct proxywasm_context *p, BufferType buffer_type, i32 start, i32 max_size, char **value, i32 *value_len);
+void set_buffer_bytes(struct proxywasm_context *p, BufferType buffer_type, i32 start, i32 size, char *value, i32 value_len);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -42,8 +42,6 @@ enum WasmResult {
   Unimplemented = 12,
 };
 
-wasm_vm_result init_proxywasm_for(wasm_vm *vm);
-
-//int this_cpu_opa_eval(const char *input);
+wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -13,7 +13,8 @@
 
 #include "runtime.h"
 
-typedef enum {
+typedef enum
+{
   WasmResult_Ok = 0,
   // The result could not be found, e.g. a provided key did not appear in a
   // table.
@@ -42,16 +43,23 @@ typedef enum {
   WasmResult_Unimplemented = 12,
 } WasmResult;
 
-typedef enum {
-    HttpRequestBody = 0,
-    HttpResponseBody = 1,
-    DownstreamData = 2,
-    UpstreamData = 3,
-    HttpCallResponseBody = 4,
-    GrpcReceiveBuffer = 5,
-    VmConfiguration = 6,
-    PluginConfiguration = 7,
+typedef enum
+{
+  HttpRequestBody = 0,
+  HttpResponseBody = 1,
+  DownstreamData = 2,
+  UpstreamData = 3,
+  HttpCallResponseBody = 4,
+  GrpcReceiveBuffer = 5,
+  VmConfiguration = 6,
+  PluginConfiguration = 7,
 } BufferType;
+
+typedef enum
+{
+  Continue = 0,
+  Pause = 1,
+} Action;
 
 struct proxywasm;
 

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -61,29 +61,40 @@ typedef enum
   Pause = 1,
 } Action;
 
-typedef enum {
+typedef enum
+{
   ListenerDirectionUnspecified = 0,
   ListenerDirectionInbound = 1,
   ListenerDirectionOutbound = 2,
 } ListenerDirection;
 
-struct proxywasm;
-struct proxywasm_context;
+typedef enum
+{
+  Unknown = 0,
+  Local = 1,
+  Remote = 2,
+} PeerType;
+
+typedef struct proxywasm proxywasm;
+typedef struct proxywasm_context proxywasm_context;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
-wasm_vm_result proxy_on_context_create(struct proxywasm *p, i32 context_id, i32 root_context_id);
-wasm_vm_result proxy_on_new_connection(struct proxywasm *p, i32 context_id);
-wasm_vm_result proxy_on_downstream_data(struct proxywasm *p, i32 context_id, i32 data_size, i32 end_of_stream);
+wasm_vm_result proxy_on_context_create(proxywasm *p, i32 context_id, i32 root_context_id);
+wasm_vm_result proxy_on_new_connection(proxywasm *p, i32 context_id);
+wasm_vm_result proxy_on_downstream_data(proxywasm *p, i32 context_id, i32 data_size, bool end_of_stream);
+wasm_vm_result proxy_on_upstream_data(proxywasm *p, i32 context_id, i32 data_size, bool end_of_stream);
+wasm_vm_result proxy_on_downstream_connection_close(proxywasm *p, i32 context_id, PeerType peer_type);
+wasm_vm_result proxy_on_upstream_connection_close(proxywasm *p, i32 context_id, PeerType peer_type);
 
 // set_property_v is convenience funtion for setting a property on a context, with simple C string paths,
 // the varargs should be path elements followed by a NULL, like: ..., "node", "id", NULL);
-void set_property_v(struct proxywasm_context *p, const char *value, const int value_len, ...);
+void set_property_v(proxywasm_context *p, const char *value, const int value_len, ...);
 
 // host functions, not needed by the API, just forward declerations
-void get_property(struct proxywasm_context *p, const char *key, int key_len, char **value, int *value_len);
-void set_property(struct proxywasm_context *p, const char *key, int key_len, const char *value, int value_len);
-void get_buffer_bytes(struct proxywasm_context *p, BufferType buffer_type, i32 start, i32 max_size, char **value, i32 *value_len);
-void set_buffer_bytes(struct proxywasm_context *p, BufferType buffer_type, i32 start, i32 size, char *value, i32 value_len);
+void get_property(proxywasm_context *p, const char *key, int key_len, char **value, int *value_len);
+void set_property(proxywasm_context *p, const char *key, int key_len, const char *value, int value_len);
+void get_buffer_bytes(proxywasm_context *p, BufferType buffer_type, i32 start, i32 max_size, char **value, i32 *value_len);
+void set_buffer_bytes(proxywasm_context *p, BufferType buffer_type, i32 start, i32 size, char *value, i32 value_len);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -88,8 +88,8 @@ wasm_vm_result proxy_on_downstream_connection_close(proxywasm *p, i32 context_id
 wasm_vm_result proxy_on_upstream_connection_close(proxywasm *p, i32 context_id, PeerType peer_type);
 
 // set_property_v is convenience funtion for setting a property on a context, with simple C string paths,
-// the varargs should be path elements followed by a NULL, like: ..., "node", "id", NULL);
-void set_property_v(proxywasm_context *p, const char *value, const int value_len, ...);
+// use the '.' as delimiter, those will be replaced to a '0' delimiter 
+void set_property_v(proxywasm_context *p, const char *key, const void *value, const int value_len);
 
 // host functions, not needed by the API, just forward declerations
 void get_property(proxywasm_context *p, const char *key, int key_len, char **value, int *value_len);

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -68,6 +68,7 @@ typedef enum {
 } ListenerDirection;
 
 struct proxywasm;
+struct proxywasm_context;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
@@ -75,8 +76,8 @@ wasm_vm_result proxy_on_context_create(struct proxywasm *p, i32 context_id, i32 
 wasm_vm_result proxy_on_new_connection(struct proxywasm *p, i32 context_id);
 wasm_vm_result proxy_on_downstream_data(struct proxywasm *p, i32 context_id, i32 data_size, i32 end_of_stream);
 
-void get_property(struct proxywasm *p, const char *key, int key_len, char **value, int *value_len);
-void set_property(struct proxywasm *p, const char *key, int key_len, const char *value, int value_len);
-void get_buffer_bytes(struct proxywasm *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len);
+void get_property(struct proxywasm_context *p, const char *key, int key_len, char **value, int *value_len);
+void set_property(struct proxywasm_context *p, const char *key, int key_len, const char *value, int value_len);
+void get_buffer_bytes(struct proxywasm_context *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -14,32 +14,32 @@
 #include "runtime.h"
 
 enum WasmResult {
-  Ok = 0,
+  WasmResult_Ok = 0,
   // The result could not be found, e.g. a provided key did not appear in a
   // table.
-  NotFound = 1,
+  WasmResult_NotFound = 1,
   // An argument was bad, e.g. did not not conform to the required range.
-  BadArgument = 2,
+  WasmResult_BadArgument = 2,
   // A protobuf could not be serialized.
-  SerializationFailure = 3,
+  WasmResult_SerializationFailure = 3,
   // A protobuf could not be parsed.
-  ParseFailure = 4,
+  WasmResult_ParseFailure = 4,
   // A provided expression (e.g. "foo.bar") was illegal or unrecognized.
-  BadExpression = 5,
+  WasmResult_BadExpression = 5,
   // A provided memory range was not legal.
-  InvalidMemoryAccess = 6,
+  WasmResult_InvalidMemoryAccess = 6,
   // Data was requested from an empty container.
-  Empty = 7,
+  WasmResult_Empty = 7,
   // The provided CAS did not match that of the stored data.
-  CasMismatch = 8,
+  WasmResult_CasMismatch = 8,
   // Returned result was unexpected, e.g. of the incorrect size.
-  ResultMismatch = 9,
+  WasmResult_ResultMismatch = 9,
   // Internal failure: trying check logs of the surrounding system.
-  InternalFailure = 10,
+  WasmResult_InternalFailure = 10,
   // The connection/stream/pipe was broken/closed unexpectedly.
-  BrokenConnection = 11,
+  WasmResult_BrokenConnection = 11,
   // Feature not implemented.
-  Unimplemented = 12,
+  WasmResult_Unimplemented = 12,
 };
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -77,6 +77,7 @@ typedef enum
 
 typedef struct proxywasm proxywasm;
 typedef struct proxywasm_context proxywasm_context;
+typedef struct proxywasm_filter proxywasm_filter;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module);
 

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -61,6 +61,12 @@ typedef enum
   Pause = 1,
 } Action;
 
+typedef enum {
+  ListenerDirectionUnspecified = 0,
+  ListenerDirectionInbound = 1,
+  ListenerDirectionOutbound = 2,
+} ListenerDirection;
+
 struct proxywasm;
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
@@ -71,6 +77,6 @@ wasm_vm_result proxy_on_downstream_data(struct proxywasm *p, i32 context_id, i32
 
 void get_property(struct proxywasm *p, const char *key, int key_len, char **value, int *value_len);
 void set_property(struct proxywasm *p, const char *key, int key_len, const char *value, int value_len);
-void get_buffer(struct proxywasm *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len, int *return_flags);
+void get_buffer_bytes(struct proxywasm *p, BufferType buffer_type, i32 offset, i32 max_size, char **value, i32 *value_len);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -79,14 +79,19 @@ typedef struct proxywasm proxywasm;
 typedef struct proxywasm_context proxywasm_context;
 typedef struct proxywasm_filter proxywasm_filter;
 
+proxywasm *proxywasm_for_vm(wasm_vm *vm);
+proxywasm *this_cpu_proxywasm(void);
+
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module);
 
 wasm_vm_result proxy_on_context_create(proxywasm *p, i32 context_id, i32 root_context_id);
-wasm_vm_result proxy_on_new_connection(proxywasm *p, i32 context_id);
-wasm_vm_result proxy_on_downstream_data(proxywasm *p, i32 context_id, i32 data_size, bool end_of_stream);
-wasm_vm_result proxy_on_upstream_data(proxywasm *p, i32 context_id, i32 data_size, bool end_of_stream);
-wasm_vm_result proxy_on_downstream_connection_close(proxywasm *p, i32 context_id, PeerType peer_type);
-wasm_vm_result proxy_on_upstream_connection_close(proxywasm *p, i32 context_id, PeerType peer_type);
+wasm_vm_result proxy_on_new_connection(proxywasm *p);
+wasm_vm_result proxy_on_downstream_data(proxywasm *p, i32 data_size, bool end_of_stream);
+wasm_vm_result proxy_on_upstream_data(proxywasm *p, i32 data_size, bool end_of_stream);
+wasm_vm_result proxy_on_downstream_connection_close(proxywasm *p, PeerType peer_type);
+wasm_vm_result proxy_on_upstream_connection_close(proxywasm *p, PeerType peer_type);
+
+wasm_vm_result proxywasm_create_context(proxywasm *p);
 
 // set_property_v is convenience funtion for setting a property on a context, with simple C string paths,
 // use the '.' as delimiter, those will be replaced to a '0' delimiter 

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -78,7 +78,7 @@ typedef enum
 typedef struct proxywasm proxywasm;
 typedef struct proxywasm_context proxywasm_context;
 
-wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
+wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module);
 
 wasm_vm_result proxy_on_context_create(proxywasm *p, i32 context_id, i32 root_context_id);
 wasm_vm_result proxy_on_new_connection(proxywasm *p, i32 context_id);

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -67,6 +67,7 @@ wasm_vm_result init_proxywasm_for(wasm_vm *vm, const char* module);
 
 wasm_vm_result proxy_on_context_create(struct proxywasm *p, i32 context_id, i32 root_context_id);
 wasm_vm_result proxy_on_new_connection(struct proxywasm *p, i32 context_id);
+wasm_vm_result proxy_on_downstream_data(struct proxywasm *p, i32 context_id, i32 data_size, i32 end_of_stream);
 
 void get_property(struct proxywasm *p, const char *key, int key_len, char **value, int *value_len);
 void set_property(struct proxywasm *p, const char *key, int key_len, const char *value, int value_len);

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ * 
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied, 
+ * modified, or distributed except according to those terms.
+ */
+
+#ifndef proxywasm_h
+#define proxywasm_h
+
+#include "runtime.h"
+
+enum WasmResult {
+  Ok = 0,
+  // The result could not be found, e.g. a provided key did not appear in a
+  // table.
+  NotFound = 1,
+  // An argument was bad, e.g. did not not conform to the required range.
+  BadArgument = 2,
+  // A protobuf could not be serialized.
+  SerializationFailure = 3,
+  // A protobuf could not be parsed.
+  ParseFailure = 4,
+  // A provided expression (e.g. "foo.bar") was illegal or unrecognized.
+  BadExpression = 5,
+  // A provided memory range was not legal.
+  InvalidMemoryAccess = 6,
+  // Data was requested from an empty container.
+  Empty = 7,
+  // The provided CAS did not match that of the stored data.
+  CasMismatch = 8,
+  // Returned result was unexpected, e.g. of the incorrect size.
+  ResultMismatch = 9,
+  // Internal failure: trying check logs of the surrounding system.
+  InternalFailure = 10,
+  // The connection/stream/pipe was broken/closed unexpectedly.
+  BrokenConnection = 11,
+  // Feature not implemented.
+  Unimplemented = 12,
+};
+
+wasm_vm_result init_proxywasm_for(wasm_vm *vm);
+
+//int this_cpu_opa_eval(const char *input);
+
+#endif

--- a/runtime.c
+++ b/runtime.c
@@ -450,6 +450,12 @@ m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
     m3ApiReturn(ret);
 }
 
+m3ApiRawFunction(m3_wasi_generic_proc_exit)
+{
+    m3ApiGetArg   (i32, code)
+    m3ApiSuccess();
+}
+
 M3Result SuppressLookupFailure(M3Result i_result)
 {
     if (i_result == m3Err_functionLookupFailed)
@@ -483,6 +489,7 @@ static M3Result m3_LinkWASI(IM3Module module)
 
     _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_get",       "i(**)", m3_wasi_generic_environ_get)));
     _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_sizes_get", "i(**)", m3_wasi_generic_environ_sizes_get)));
+    _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "proc_exit",           "(i)", m3_wasi_generic_proc_exit)));
 
 _catch:
     return result;

--- a/runtime.c
+++ b/runtime.c
@@ -415,22 +415,6 @@ m3ApiRawFunction(m3_wasi_generic_environ_get)
     m3ApiGetArgMem   (uint32_t *           , env)
     m3ApiGetArgMem   (char *               , env_buf)
 
-    uint32_t ret = 0;
-    // __wasi_size_t env_count, env_buf_size;
-
-    // ret = __wasi_environ_sizes_get(&env_count, &env_buf_size);
-    // if (ret != __WASI_ERRNO_SUCCESS) m3ApiReturn(ret);
-
-    // m3ApiCheckMem(env,      env_count * sizeof(uint32_t));
-    // m3ApiCheckMem(env_buf,  env_buf_size);
-
-    // ret = __wasi_environ_get(env, env_buf);
-    // if (ret != __WASI_ERRNO_SUCCESS) m3ApiReturn(ret);
-
-    // for (u32 i = 0; i < env_count; ++i) {
-    //     env[i] = m3ApiPtrToOffset (env[i]);
-    // }
-
     m3ApiReturn(0);
 }
 
@@ -445,8 +429,6 @@ m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
 
     *env_count = 0;
     *env_buf_size = 0;
-
-    uint32_t ret = 0; //__wasi_environ_sizes_get(env_count, env_buf_size);
 
     m3ApiReturn(0);
 }

--- a/runtime.c
+++ b/runtime.c
@@ -79,13 +79,18 @@ wasm_vm *this_cpu_wasm_vm(void)
 {
     int cpu = get_cpu();
     put_cpu();
-    return vms[smp_processor_id()];
+    return vms[cpu];
 }
 
 wasm_vm *wasm_vm_for_cpu(unsigned cpu)
 {
     if (cpu >= nr_cpu_ids) return NULL;
     return vms[cpu];
+}
+
+const char *wasm_vm_last_error(wasm_vm *vm)
+{
+    return vm->_runtime->error_message;
 }
 
 wasm_vm_result wasm_vm_new_per_cpu(void)
@@ -185,7 +190,7 @@ wasm_vm_result wasm_vm_load_module(wasm_vm *vm, const char *name, unsigned char 
         wasm_bins[wasm_bins_qty++] = wasm;
     }
 
-    return (wasm_vm_result){.err = NULL};
+    return (wasm_vm_result){.data = {{.module = module}}, .err = NULL};
 
 on_error:
     m3_FreeModule(module);
@@ -262,9 +267,13 @@ wasm_vm_result wasm_vm_call_direct(wasm_vm *vm, wasm_vm_function *func, ...)
 
 wasm_vm_result wasm_vm_call(wasm_vm *vm, const char *module, const char *name, ...)
 {
-    wasm_vm_function *func = wasm_vm_get_function(vm, module, name);
-    if (!func)
-        return (wasm_vm_result){.err = m3Err_functionLookupFailed};
+    wasm_vm_result result = wasm_vm_get_function(vm, module, name);
+    if (result.err)
+    {
+        return result;
+    }
+
+    wasm_vm_function *func = result.data->function;
 
     va_list ap;
     va_start(ap, name);
@@ -400,6 +409,47 @@ m3ApiRawFunction(m3_ext_submit_metric)
     m3ApiReturn(i_size);
 }
 
+m3ApiRawFunction(m3_wasi_generic_environ_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *           , env)
+    m3ApiGetArgMem   (char *               , env_buf)
+
+    uint32_t ret = 0;
+    // __wasi_size_t env_count, env_buf_size;
+
+    // ret = __wasi_environ_sizes_get(&env_count, &env_buf_size);
+    // if (ret != __WASI_ERRNO_SUCCESS) m3ApiReturn(ret);
+
+    // m3ApiCheckMem(env,      env_count * sizeof(uint32_t));
+    // m3ApiCheckMem(env_buf,  env_buf_size);
+
+    // ret = __wasi_environ_get(env, env_buf);
+    // if (ret != __WASI_ERRNO_SUCCESS) m3ApiReturn(ret);
+
+    // for (u32 i = 0; i < env_count; ++i) {
+    //     env[i] = m3ApiPtrToOffset (env[i]);
+    // }
+
+    m3ApiReturn(ret);
+}
+
+m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
+{
+    m3ApiReturnType  (uint32_t)
+    m3ApiGetArgMem   (uint32_t *      , env_count)
+    m3ApiGetArgMem   (uint32_t *      , env_buf_size)
+
+    m3ApiCheckMem(env_count,    sizeof(uint32_t));
+    m3ApiCheckMem(env_buf_size, sizeof(uint32_t));
+
+    *env_count = 0;
+
+    uint32_t ret = 0; //__wasi_environ_sizes_get(env_count, env_buf_size);
+
+    m3ApiReturn(ret);
+}
+
 M3Result SuppressLookupFailure(M3Result i_result)
 {
     if (i_result == m3Err_functionLookupFailed)
@@ -424,6 +474,20 @@ _catch:
     return result;
 }
 
+// Some Wasi mockings only for proxy-wasm
+static M3Result m3_LinkWASI(IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+    const char *wasi = "wasi_snapshot_preview1";
+
+    _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_get",       "i(**)", m3_wasi_generic_environ_get)));
+    _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_sizes_get", "i(**)", m3_wasi_generic_environ_sizes_get)));
+
+_catch:
+    return result;
+}
+
 static M3Result m3_link_all(IM3Module module)
 {
     M3Result res = NULL;
@@ -435,11 +499,11 @@ static M3Result m3_link_all(IM3Module module)
     if (res)
         return res;
 
-#if defined(LINK_WASI)
+// #if defined(LINK_WASI)
     res = m3_LinkWASI(module);
     if (res)
         return res;
-#endif
+// #endif
 
 #if defined(d_m3HasTracer)
     res = m3_LinkTracer(module);
@@ -484,7 +548,7 @@ static void *print_module_symbols(IM3Module module, void * i_info)
     {
         IM3Function f = & module->functions [i];
 
-        if (f->numNames > 1) {
+        if (f->numNames >= 1) {
             printk("wasm:     function -> %s(%d) -> %d", f->names[0], f->funcType->numArgs, f->funcType->numRets);
         }
     }
@@ -508,19 +572,17 @@ void wasm_vm_unlock(wasm_vm *vm)
     spin_unlock_irqrestore(&vm->_lock, vm->_lock_flags);
 }
 
-wasm_vm_module *wasm_vm_get_module(wasm_vm *vm, const char *module)
+wasm_vm_result wasm_vm_get_module(wasm_vm *vm, const char *name)
 {
-    return (wasm_vm_module*) ForEachModule (vm->_runtime, (ModuleVisitor) v_FindModule, (void *) module);
+    wasm_vm_module* module = ForEachModule (vm->_runtime, (ModuleVisitor) v_FindModule, (void *) name);
+
+    return (wasm_vm_result){.data = {{.module = module}}};
 }
 
-wasm_vm_function *wasm_vm_get_function(wasm_vm *vm, const char *module, const char *name)
+wasm_vm_result wasm_vm_get_function(wasm_vm *vm, const char *module, const char *name)
 {
-    M3Result result = m3Err_none;
-    IM3Function func = NULL;
+    IM3Function function = NULL;
+    M3Result result = m3_FindFunctionInModule(&function, vm->_runtime, module, name);
 
-    result = m3_FindFunctionInModule(&func, vm->_runtime, module, name);
-    if (result)
-        return NULL;
-
-    return func;
+    return (wasm_vm_result){.data = {{.function = function}}, .err = result};
 }

--- a/runtime.c
+++ b/runtime.c
@@ -481,7 +481,7 @@ _catch:
 }
 
 // Some Wasi mockings only for proxy-wasm
-static M3Result m3_LinkWASI(IM3Module module)
+static M3Result m3_LinkWASIMocks(IM3Module module)
 {
     M3Result result = m3Err_none;
 
@@ -506,11 +506,9 @@ static M3Result m3_link_all(IM3Module module)
     if (res)
         return res;
 
-// #if defined(LINK_WASI)
-    res = m3_LinkWASI(module);
+    res = m3_LinkWASIMocks(module);
     if (res)
         return res;
-// #endif
 
 #if defined(d_m3HasTracer)
     res = m3_LinkTracer(module);
@@ -553,13 +551,14 @@ static void *print_module_symbols(IM3Module module, void * i_info)
     }
     for (i = 0; i < module->numFunctions; i++)
     {
-        IM3Function f = & module->functions [i];
+        IM3Function f = &module->functions[i];
 
-        if (f->numNames > 1) {
-            printk("wasm:     function -> %s(%d) -> %d", f->names[0], f->funcType->numArgs, f->funcType->numRets);
+        if (f->export_name != NULL)
+        {
+            printk("wasm:     function -> %s(%d) -> %d", f->export_name, f->funcType->numArgs, f->funcType->numRets);
         }
     }
-    
+
     return NULL;
 }
 
@@ -581,7 +580,7 @@ void wasm_vm_unlock(wasm_vm *vm)
 
 wasm_vm_result wasm_vm_get_module(wasm_vm *vm, const char *name)
 {
-    wasm_vm_module* module = ForEachModule (vm->_runtime, (ModuleVisitor) v_FindModule, (void *) name);
+    wasm_vm_module *module = ForEachModule(vm->_runtime, (ModuleVisitor)v_FindModule, (void *)name);
 
     return (wasm_vm_result){.data = {{.module = module}}};
 }

--- a/runtime.c
+++ b/runtime.c
@@ -431,7 +431,7 @@ m3ApiRawFunction(m3_wasi_generic_environ_get)
     //     env[i] = m3ApiPtrToOffset (env[i]);
     // }
 
-    m3ApiReturn(ret);
+    m3ApiReturn(0);
 }
 
 m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
@@ -444,10 +444,11 @@ m3ApiRawFunction(m3_wasi_generic_environ_sizes_get)
     m3ApiCheckMem(env_buf_size, sizeof(uint32_t));
 
     *env_count = 0;
+    *env_buf_size = 0;
 
     uint32_t ret = 0; //__wasi_environ_sizes_get(env_count, env_buf_size);
 
-    m3ApiReturn(ret);
+    m3ApiReturn(0);
 }
 
 m3ApiRawFunction(m3_wasi_generic_proc_exit)

--- a/runtime.c
+++ b/runtime.c
@@ -548,7 +548,7 @@ static void *print_module_symbols(IM3Module module, void * i_info)
     {
         IM3Function f = & module->functions [i];
 
-        if (f->numNames >= 1) {
+        if (f->numNames > 1) {
             printk("wasm:     function -> %s(%d) -> %d", f->names[0], f->funcType->numArgs, f->funcType->numRets);
         }
     }

--- a/runtime.h
+++ b/runtime.h
@@ -22,8 +22,7 @@
     }
 
 // MAX_RETURN_VALUES defines the amount of return values.
-// currently only 5 return value supported per function.
-#define MAX_RETURN_VALUES 5
+#define MAX_RETURN_VALUES 3
 
 typedef struct wasm_vm
 {
@@ -35,6 +34,9 @@ typedef struct wasm_vm
     IM3Runtime _runtime;
 } wasm_vm;
 
+typedef M3Module wasm_vm_module;
+typedef M3Function wasm_vm_function;
+
 typedef struct wasm_vm_result
 {
     union
@@ -43,12 +45,13 @@ typedef struct wasm_vm_result
         i64 i64;
         f32 f32;
         f64 f64;
+        wasm_vm_module *module;
+        wasm_vm_function *function;
     } data[MAX_RETURN_VALUES];
-    char *err;
+    const char *err;
 } wasm_vm_result;
 
-typedef M3Module wasm_vm_module;
-typedef M3Function wasm_vm_function;
+#define wasm_vm_try_get_function(VAR, CALL) { result = CALL; if (result.err) goto error; VAR = result.data->function; }
 
 wasm_vm *wasm_vm_for_cpu(unsigned cpu);
 wasm_vm *this_cpu_wasm_vm(void);
@@ -67,8 +70,9 @@ void wasm_vm_set_userdata(wasm_vm *vm, void *userdata);
 void wasm_vm_dump_symbols(wasm_vm *vm);
 void wasm_vm_lock(wasm_vm *vm);
 void wasm_vm_unlock(wasm_vm *vm);
-wasm_vm_module *wasm_vm_get_module(wasm_vm *vm, const char *module);
-wasm_vm_function *wasm_vm_get_function(wasm_vm *vm, const char *module, const char *function);
+wasm_vm_result wasm_vm_get_module(wasm_vm *vm, const char *module);
+wasm_vm_result wasm_vm_get_function(wasm_vm *vm, const char *module, const char *function);
+const char *wasm_vm_last_error(wasm_vm *vm);
 
 M3Result SuppressLookupFailure(M3Result i_result);
 


### PR DESCRIPTION
## Description

This is very draft version of this feature, that makes the kernel module accept and run [proxy-wasm](https://github.com/proxy-wasm/spec) modules:

After inserting the module to a Lima VM kernel, run:

```bash
cd wasm-kernel-module-cli

lima sudo ./cli/cli load -name proxywasm_tcp -file $HOME/Code/src/github.com/cisco-open/nasp/target/wasm32-unknown-unknown/release/wasm_tcp_metadata.wasm -entrypoint _start

lima sudo ./cli/cli load -name proxywasm_stats -file $HOME/Code/src/github.com/cisco-open/nasp/pkg/istio/filters/stats-filter.wasm -entrypoint _initialize

# Do some tests

lima sudo sh -c "echo '{\"command\":\"proxywasm_test\"}' > /dev/wasm"

```
## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
