### PR TITLE
remove socket type and inet_ methods

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -14,8 +14,6 @@
 #include <linux/tcp.h>
 #include <linux/version.h>
 #include <net/tcp.h>
-#include <net/tcp_states.h>
-#include <net/inet_common.h>
 #include <net/sock.h>
 #include <net/ip.h>
 #include <linux/uaccess.h>
@@ -40,16 +38,7 @@ const char *ALPNs[] = {
 
 const size_t ALPNs_NUM = sizeof(ALPNs) / sizeof(ALPNs[0]);
 
-struct proto wasm_prot;
-struct proto inet_wasm_prot;
-struct proto_ops inet_wasm_ops;
-static struct inet_protosw wasm_sw = {
-	.type = SOCK_WASM,
-	.protocol = IPPROTO_TCP,
-	.prot = &inet_wasm_prot,
-	.ops = &inet_wasm_ops,
-	.flags = INET_PROTOSW_ICSK,
-};
+static struct proto wasm_prot;
 
 typedef struct
 {
@@ -338,183 +327,6 @@ sock_write(void *ctx, const unsigned char *buf, size_t len)
 	}
 }
 
-/* This is a copy of inet_listen, but uses SOCK_WASM instead of SOCK_STREAM
-   This allows us to listen on SOCK_WASM sockets.
-*/
-int inet_wasm_listen(struct socket *sock, int backlog)
-{
-	struct sock *sk = sock->sk;
-	unsigned char old_state;
-	int err;
-
-	lock_sock(sk);
-
-	err = -EINVAL;
-	if (sock->state != SS_UNCONNECTED || sock->type != SOCK_WASM)
-		goto out;
-
-	old_state = sk->sk_state;
-	if (!((1 << old_state) & (TCPF_CLOSE | TCPF_LISTEN)))
-		goto out;
-
-	/* Really, if the socket is already in listen state
-	 * we can only allow the backlog to be adjusted.
-	 */
-	if (old_state != TCP_LISTEN)
-	{
-		err = inet_csk_listen_start(sk
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
-									,
-									backlog
-#endif
-		);
-		if (err)
-			goto out;
-	}
-	sk->sk_max_ack_backlog = backlog;
-	err = 0;
-
-out:
-	release_sock(sk);
-	return err;
-}
-
-int inet_wasm_accept(struct socket *sock, struct socket *newsock, int flags, bool kern)
-{
-	int ret = inet_accept(sock, newsock, flags, kern);
-
-	// printk("inet_wasm_accept %d", ret);
-
-	if (ret == 0)
-	{
-		wasm_socket_context *sc = new_server_wasm_socket_context(NULL);
-
-		/*
-		 * Initialise the context with the cipher suites and
-		 * algorithms. This depends on the server key type
-		 * (and, for EC keys, the signature algorithm used by
-		 * the CA to sign the server's certificate).
-		 *
-		 * Depending on the defined macros, we may select one of
-		 * the "minimal" profiles. Key exchange algorithm depends
-		 * on the key type:
-		 *   RSA key: RSA or ECDHE_RSA
-		 *   EC key, cert signed with ECDSA: ECDH_ECDSA or ECDHE_ECDSA
-		 *   EC key, cert signed with RSA: ECDH_RSA or ECDHE_ECDSA
-		 */
-#if !RSA_OR_EC
-		br_ssl_server_init_full_rsa(sc->sc, CHAIN, CHAIN_LEN, &RSA);
-#elif
-		br_ssl_server_init_full_ec(sc->sc, CHAIN, CHAIN_LEN, BR_KEYTYPE_EC, &EC);
-#endif
-
-		/*
-		 * Set the I/O buffer to the provided array. We
-		 * allocated a buffer large enough for full-duplex
-		 * behaviour with all allowed sizes of SSL records,
-		 * hence we set the last argument to 1 (which means
-		 * "split the buffer into separate input and output
-		 * areas").
-		 */
-		br_ssl_engine_set_buffer(&sc->sc->eng, sc->iobuf, BR_SSL_BUFSIZE_BIDI, true);
-
-		/*
-		 * Reset the server context, for a new handshake.
-		 */
-		br_ssl_server_reset(sc->sc);
-
-		/*
-		 * Initialise the simplified I/O wrapper context.
-		 */
-		br_sslio_init(&sc->ioc, &sc->sc->eng, sock_read, newsock->sk, sock_write, newsock->sk);
-
-		// We should save the ssl context here to the socket
-		newsock->sk->sk_user_data = sc;
-
-		if (br_sslio_flush(&sc->ioc) == 0)
-		{
-			printk("inet_wasm_accept: TLS handshake done");
-		}
-	}
-
-	return ret;
-}
-
-int inet_wasm_connect(struct socket *sock,
-					  struct sockaddr *vaddr,
-					  int sockaddr_len, int flags)
-{
-	int ret = inet_stream_connect(sock, vaddr, sockaddr_len, flags);
-
-	if (ret == 0)
-	{
-		const char *server_name = NULL; // TODO, this needs to be sourced down here
-
-		wasm_socket_context *sc = new_client_wasm_socket_context(NULL);
-
-		/*
-		 * Initialise the context with the cipher suites and
-		 * algorithms. This depends on the server key type
-		 * (and, for EC keys, the signature algorithm used by
-		 * the CA to sign the server's certificate).
-		 *
-		 * Depending on the defined macros, we may select one of
-		 * the "minimal" profiles. Key exchange algorithm depends
-		 * on the key type:
-		 *   RSA key: RSA or ECDHE_RSA
-		 *   EC key, cert signed with ECDSA: ECDH_ECDSA or ECDHE_ECDSA
-		 *   EC key, cert signed with RSA: ECDH_RSA or ECDHE_ECDSA
-		 */
-		br_ssl_client_init_full(sc->cc, &sc->xc, TAs, TAs_NUM);
-
-		/*
-		 * Set the I/O buffer to the provided array. We
-		 * allocated a buffer large enough for full-duplex
-		 * behaviour with all allowed sizes of SSL records,
-		 * hence we set the last argument to 1 (which means
-		 * "split the buffer into separate input and output
-		 * areas").
-		 */
-		br_ssl_engine_set_buffer(&sc->cc->eng, &sc->iobuf, BR_SSL_BUFSIZE_BIDI, true);
-
-		/*
-		 * Reset the client context, for a new handshake. We provide the
-		 * target host name: it will be used for the SNI extension. The
-		 * last parameter is 0: we are not trying to resume a session.
-		 */
-		if (br_ssl_client_reset(sc->cc, server_name, 0) != 1)
-		{
-			pr_err("br_ssl_client_reset returned an error");
-		}
-
-		/*
-		 * Initialise the simplified I/O wrapper context, to use our
-		 * SSL client context, and the two callbacks for socket I/O.
-		 */
-		br_sslio_init(&sc->ioc, &sc->cc->eng, sock_read, sock->sk, sock_write, sock->sk);
-
-		// We should save the ssl context here to the socket
-		sock->sk->sk_user_data = sc;
-
-		if (br_sslio_flush(&sc->ioc) != 0)
-		{
-			pr_err("br_sslio_flush returned an error: %d", br_ssl_engine_last_error(&sc->cc->eng));
-		}
-
-		printk("inet_wasm_connect: TLS handshake done");
-	}
-
-	return ret;
-}
-
-int inet_wasm_shutdown(struct socket *sock, int how)
-{
-	wasm_socket_context *c = sock->sk->sk_user_data;
-	free_wasm_socket_context(c);
-	sock->sk->sk_user_data = NULL;
-	return inet_shutdown(sock, how);
-}
-
 void dump_msghdr(struct msghdr *msg)
 {
 	char data[1024];
@@ -615,8 +427,6 @@ int wasm_recvmsg(struct sock *sock,
 		return -1;
 	}
 
-	// printk(KERN_INFO "inet_wasm_recvmsg -> br_sslio_read: %d bytes -> %.*s\n", ret, ret, dst);
-
 	int read_buffer_size = get_read_buffer_size(c);
 
 	len = copy_to_iter(get_read_buffer(c), read_buffer_size, &msg->msg_iter);
@@ -632,16 +442,6 @@ int wasm_recvmsg(struct sock *sock,
 bail:
 
 	return ret;
-}
-
-int inet_wasm_recvmsg(struct socket *sock, struct msghdr *msg, size_t size,
-					  int flags)
-{
-	return wasm_recvmsg(sock->sk, msg, size,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
-						0,
-#endif
-						flags, 0);
 }
 
 int wasm_sendmsg(struct sock *sock, struct msghdr *msg, size_t size)
@@ -687,8 +487,6 @@ int wasm_sendmsg(struct sock *sock, struct msghdr *msg, size_t size)
 	//	len = copy_from_iter(data, min(size, sizeof(data)), &msg->msg_iter);
 	len = copy_from_iter(get_write_buffer_for_write(c), min(size, get_write_buffer_capacity(c)), &msg->msg_iter);
 
-	// printk("inet_wasm_sendmsg data %.*s len = %d", size, data, len);
-
 	set_write_buffer_size(c, get_write_buffer_size(c) + len);
 
 	proxywasm_lock(c->p);
@@ -711,9 +509,6 @@ int wasm_sendmsg(struct sock *sock, struct msghdr *msg, size_t size)
 		ret = -1;
 		goto bail;
 	}
-
-	// a realloc might have happened
-	// data = c->pc->write_buffer;
 
 	// printk("wasm_sendmsg: %s br_sslio_write_all get_write_buffer_size = %d", get_direction(c), get_write_buffer_size(c));
 
@@ -741,11 +536,6 @@ int wasm_sendmsg(struct sock *sock, struct msghdr *msg, size_t size)
 bail:
 
 	return ret;
-}
-
-int inet_wasm_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
-{
-	return wasm_sendmsg(sock->sk, msg, size);
 }
 
 void wasm_shutdown(struct sock *sk, int how)
@@ -951,40 +741,6 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 
 int wasm_socket_init(void)
 {
-	int rc = -EINVAL;
-
-	/* functions for a listening socket of type SOCK_WASM */
-	memcpy(&inet_wasm_ops, &inet_stream_ops, sizeof(inet_wasm_ops));
-	inet_wasm_ops.listen = inet_wasm_listen;
-	inet_wasm_ops.accept = inet_wasm_accept;
-	inet_wasm_ops.connect = inet_wasm_connect;
-	inet_wasm_ops.recvmsg = inet_wasm_recvmsg;
-	inet_wasm_ops.sendmsg = inet_wasm_sendmsg;
-	inet_wasm_ops.shutdown = inet_wasm_shutdown;
-
-	/* Not all tcp_prot's members were exported from the kernel,
-	   so we use this hack to grab them from the exported tcp_prot struct,
-	   and fill in our own.
-	*/
-	memcpy(&inet_wasm_prot, &tcp_prot, sizeof(inet_wasm_prot));
-	strncpy(inet_wasm_prot.name, "WASM", sizeof(inet_wasm_prot.name));
-	inet_wasm_prot.owner = THIS_MODULE;
-
-	/* proto_register will only alloc twsk_prot and rsk_prot if they are
-	   null no sense in allocing more space - we can just use TCP's, since
-	   we are effecitvely just a TCP socket
-	  (though it will alloc .slab even if non-null - we let it).
-	*/
-	rc = proto_register(&inet_wasm_prot, 1);
-	if (rc)
-	{
-		printk(KERN_CRIT "wasm_init: Cannot register protocol"
-						 "(already loaded?)\n");
-		return rc;
-	}
-
-	inet_register_protosw(&wasm_sw);
-
 	// let's overwrite tcp_port with our own implementation
 	accept = tcp_prot.accept;
 	connect = tcp_prot.connect;
@@ -1005,17 +761,6 @@ int wasm_socket_init(void)
 
 void wasm_socket_exit(void)
 {
-	/* Currently, we're pointing to tcp_prot's twsk_prot and rsk_prot
-	   and a call to proto_unregister will free these if non-null.
-	   (We did allocate our own slab though, so proto_unregister will free
-		that for us)
-	*/
-	inet_wasm_prot.rsk_prot = NULL;
-	inet_wasm_prot.twsk_prot = NULL;
-
-	inet_unregister_protosw(&wasm_sw);
-	proto_unregister(&inet_wasm_prot);
-
 	tcp_prot.accept = accept;
 	tcp_prot.connect = connect;
 

--- a/socket.h
+++ b/socket.h
@@ -11,8 +11,6 @@
 #ifndef _WASM_H
 #define _WASM_H
 
-#define SOCK_WASM 9 /* new protocol */
-
 int wasm_socket_init(void);
 void wasm_socket_exit(void);
 


### PR DESCRIPTION
## Description

The socket type method is removed in favour of the new "transparent" socket type.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
