### PR TITLE
runtime: hide struct members and fix module loading glitches

### DIFF
--- a/opa.c
+++ b/opa.c
@@ -204,7 +204,7 @@ error:
 
     opa_free(opa, builtinsJson);
 
-    opas[vm->cpu] = opa;
+    opas[wasm_vm_cpu(vm)] = opa;
 
     return (wasm_vm_result){.err = NULL};
 }

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -125,7 +125,7 @@ wasm_vm_result proxy_on_memory_allocate(proxywasm_filter *filter, i32 size)
 
 proxywasm *proxywasm_for_vm(wasm_vm *vm)
 {
-    return proxywasms[vm->cpu];
+    return proxywasms[wasm_vm_cpu(vm)];
 }
 
 proxywasm* this_cpu_proxywasm(void)
@@ -371,13 +371,13 @@ void print_property_key(const char *func, const char *key, int key_len)
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module)
 {
-    proxywasm *proxywasm = proxywasms[vm->cpu];
+    proxywasm *proxywasm = proxywasms[wasm_vm_cpu(vm)];
 
     if (proxywasm == NULL)
     {
         proxywasm = kzalloc(sizeof(struct proxywasm), GFP_KERNEL);
         proxywasm->vm = vm;
-        proxywasms[vm->cpu] = proxywasm;
+        proxywasms[wasm_vm_cpu(vm)] = proxywasm;
 
         proxywasm_context *root_context = new_proxywasm_context(NULL);
         printk("wasm: root_context_id %d", root_context->id);


### PR DESCRIPTION
## Description

Hide all members of the VM struct, fix module loading leaks and limits.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
