### PR TITLE
implement sync command answering

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,13 @@ make logs
 Install the [CLI](https://github.com/cisco-open/wasm-kernel-module-cli) for the kernel module:
 
 ```bash
+# You can build the module on your workstation
 git clone https://github.com/cisco-open/wasm-kernel-module-cli.git
 cd wasm-kernel-module-cli
+make build-cli
+
+# But you need to run it in the VM, where the device is exposed
+lima sudo ./w3k server
 ```
 
 Then follow the instructions [here](https://github.com/cisco-open/wasm-kernel-module-cli#cli).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This Linux Kernel module runs and exposes a [Wasm](https://webassembly.org) runt
 - Wasm is capable of running the kernel space
 - running code in kernel space in almost all languages compiled to Wasm
 - expose Wasm functionality written in Wasm to eBPF securely
+- run [proxy-wasm](https://github.com/proxy-wasm/spec) filters on TCP sockets
 
 ## Why doing this?
 

--- a/device_driver.c
+++ b/device_driver.c
@@ -39,9 +39,10 @@ static atomic_t already_open = ATOMIC_INIT(CDEV_NOT_USED);
 typedef struct command
 {
     struct list_head list;
+    char *name;
     char *data;
-    size_t size;
-    int id;
+    size_t data_size;
+    uuid_t uuid;
     struct command_answer *answer;
     wait_queue_head_t wait_queue;
 };
@@ -52,7 +53,7 @@ static unsigned long command_list_lock_flags;
 static LIST_HEAD(command_list);
 static LIST_HEAD(in_flight_command_list);
 
-static struct command *lookup_in_flight_command(int id)
+static struct command *lookup_in_flight_command(char *id)
 {
     spin_lock_irqsave(&command_list_lock, command_list_lock_flags);
 
@@ -60,7 +61,7 @@ static struct command *lookup_in_flight_command(int id)
     struct command *tmp;
     list_for_each_entry(tmp, &in_flight_command_list, list)
     {
-        if (tmp->id == id)
+        if (strncmp(tmp->uuid.b, id, UUID_SIZE) == 0)
         {
             cmd = tmp;
             break;
@@ -88,16 +89,18 @@ void free_command_answer(struct command_answer *cmd_answer)
 }
 
 // create a function to add a command to the list (called from the VM), locked with a spinlock
-command_answer *send_command(char *data, size_t size)
+command_answer *send_command(char *name, char *data, size_t data_size)
 {
-    struct command *cmd = kmalloc(sizeof(struct command), GFP_KERNEL);
-    cmd->data = kmalloc(size, GFP_KERNEL);
-    memcpy(cmd->data, data, size);
-    cmd->size = size;
-    init_waitqueue_head(&cmd->wait_queue);
+    struct command cmd;
+
+    uuid_gen(&cmd.uuid);
+    cmd.name = name;
+    cmd.data = data;
+    cmd.data_size = data_size;
+    init_waitqueue_head(&cmd.wait_queue);
 
     spin_lock_irqsave(&command_list_lock, command_list_lock_flags);
-    list_add_tail(&cmd->list, &command_list);
+    list_add_tail(&cmd.list, &command_list);
     spin_unlock_irqrestore(&command_list_lock, command_list_lock_flags);
 
     DEFINE_WAIT(wait);
@@ -106,27 +109,27 @@ command_answer *send_command(char *data, size_t size)
     printk("wasm: waiting for command to be processed");
 
     // wait for the command to be processed
-    prepare_to_wait(&cmd->wait_queue, &wait, TASK_INTERRUPTIBLE);
+    prepare_to_wait(&cmd.wait_queue, &wait, TASK_INTERRUPTIBLE);
     // Sleep until the condition is true or the timeout expires
     unsigned long timeout = msecs_to_jiffies(COMMAND_TIMEOUT_SECONDS * 1000);
     schedule_timeout(timeout);
 
-    finish_wait(&cmd->wait_queue, &wait);
+    finish_wait(&cmd.wait_queue, &wait);
 
-    if (cmd->answer == NULL)
+    if (cmd.answer == NULL)
     {
         printk(KERN_ERR "wasm: command answer timeout");
 
-        cmd->answer = kmalloc(sizeof(struct command_answer), GFP_KERNEL);
-        cmd->answer->error = kmalloc(strlen("timeout") + 1, GFP_KERNEL);
-        strcpy(cmd->answer->error, "timeout");
+        cmd.answer = kmalloc(sizeof(struct command_answer), GFP_KERNEL);
+        cmd.answer->error = kmalloc(strlen("timeout") + 1, GFP_KERNEL);
+        strcpy(cmd.answer->error, "timeout");
     }
 
     spin_lock_irqsave(&command_list_lock, command_list_lock_flags);
-    list_del(&cmd->list);
+    list_del(&cmd.list);
     spin_unlock_irqrestore(&command_list_lock, command_list_lock_flags);
 
-    return cmd->answer;
+    return cmd.answer;
 }
 
 // create a function to get a command from the list (called from the driver), locked with a mutex
@@ -146,8 +149,42 @@ static struct command *get_command(void)
     return cmd;
 }
 
+// generate function to write command as json to a buffer
+int write_command_to_buffer(char *buffer, size_t buffer_size, struct command *cmd)
+{
+    JSON_Value *root_value = json_value_init_object();
+    JSON_Object *root_object = json_value_get_object(root_value);
+
+    char uuid[UUID_SIZE * 2];
+    base64_encode(uuid, UUID_SIZE * 2, cmd->uuid.b, UUID_SIZE);
+    json_object_set_string(root_object, "id", uuid);
+
+    json_object_set_string(root_object, "command", cmd->name);
+
+    if (cmd->data)
+    {
+        json_object_set_string(root_object, "data", cmd->data);
+    }
+
+    char *serialized_string = json_serialize_to_string(root_value);
+    int length = strlen(serialized_string);
+    if (length > buffer_size)
+    {
+        printk(KERN_ERR "wasm: command buffer too small: %d", length);
+        return -1;
+    }
+
+    strcpy(buffer, serialized_string);
+    json_free_serialized_string(serialized_string);
+    json_value_free(root_value);
+
+    return length;
+}
+
 static char device_buffer[DEVICE_BUFFER_SIZE];
 static size_t device_buffer_size = 0;
+
+static char device_out_buffer[64 * 1024];
 
 static struct class *cls;
 
@@ -345,9 +382,18 @@ int parse_json_from_buffer(void)
         }
         else if (strcmp("answer", command) == 0)
         {
-            printk("wasm: command answer parsing");
+            char *base64_id = json_object_get_string(root, "id");
 
-            int command_id = json_object_get_number(root, "id");
+            printk("wasm: command answer parsing, id: %s", base64_id);
+
+            char command_id[UUID_SIZE * 2];
+            int length = base64_decode(command_id, UUID_SIZE * 2, base64_id, strlen(base64_id));
+            if (length < 0)
+            {
+                FATAL("base64_decode of id failed");
+                status = -1;
+                goto cleanup;
+            }
 
             struct command *cmd = lookup_in_flight_command(command_id);
 
@@ -475,13 +521,20 @@ static ssize_t device_read(struct file *file,   /* see include/linux/fs.h   */
         c = get_command();
     }
 
-    // copy the command to the buffer
+    int json_length = write_command_to_buffer(device_out_buffer, sizeof device_out_buffer, c);
+    if (json_length < 0)
+    { 
+        return -EFAULT;
+    }
+
+    printk("wasm: the command json is done: %s", device_out_buffer);
+
     int bytes_read = 0;
-    int bytes_to_read = c->size; // min(length, c->size - *offset);
+    int bytes_to_read = json_length; // min(length, c->size - *offset);
     if (bytes_to_read > 0)
     {
         // if (copy_to_user(buffer, c->data + *offset, bytes_to_read))
-        if (copy_to_user(buffer, c->data, bytes_to_read))
+        if (copy_to_user(buffer, device_out_buffer, bytes_to_read))
         {
             return -EFAULT;
         }

--- a/device_driver.c
+++ b/device_driver.c
@@ -10,6 +10,7 @@
 
 #include <linux/uaccess.h>
 #include <linux/delay.h>
+#include <linux/wait.h>
 
 #include "base64.h"
 #include "device_driver.h"
@@ -21,6 +22,7 @@
 /* Global variables are declared as static, so are global within the file. */
 
 #define DEFAULT_MODULE_ENTRYPOINT "main"
+#define COMMAND_TIMEOUT_SECONDS 5
 
 static int major; /* major number assigned to our device driver */
 
@@ -39,24 +41,92 @@ typedef struct command
     struct list_head list;
     char *data;
     size_t size;
+    int id;
+    struct command_answer *answer;
+    wait_queue_head_t wait_queue;
 };
 
 // protect the command list with a mutex
 static DEFINE_SPINLOCK(command_list_lock);
 static unsigned long command_list_lock_flags;
 static LIST_HEAD(command_list);
+static LIST_HEAD(in_flight_command_list);
+
+static struct command *lookup_in_flight_command(int id)
+{
+    spin_lock_irqsave(&command_list_lock, command_list_lock_flags);
+
+    struct command *cmd = NULL;
+    struct command *tmp;
+    list_for_each_entry(tmp, &in_flight_command_list, list)
+    {
+        if (tmp->id == id)
+        {
+            cmd = tmp;
+            break;
+        }
+    }
+
+    spin_unlock_irqrestore(&command_list_lock, command_list_lock_flags);
+
+    return cmd;
+}
+
+void free_command_answer(struct command_answer *cmd_answer)
+{
+    if (cmd_answer->error)
+    {
+        kfree(cmd_answer->error);
+    }
+
+    if (cmd_answer->answer)
+    {
+        kfree(cmd_answer->answer);
+    }
+
+    kfree(cmd_answer);
+}
 
 // create a function to add a command to the list (called from the VM), locked with a spinlock
-void send_command(char *data, size_t size)
+command_answer *send_command(char *data, size_t size)
 {
     struct command *cmd = kmalloc(sizeof(struct command), GFP_KERNEL);
     cmd->data = kmalloc(size, GFP_KERNEL);
     memcpy(cmd->data, data, size);
     cmd->size = size;
+    init_waitqueue_head(&cmd->wait_queue);
 
     spin_lock_irqsave(&command_list_lock, command_list_lock_flags);
     list_add_tail(&cmd->list, &command_list);
     spin_unlock_irqrestore(&command_list_lock, command_list_lock_flags);
+
+    DEFINE_WAIT(wait);
+
+    // wait until the command is processed
+    printk("wasm: waiting for command to be processed");
+
+    // wait for the command to be processed
+    prepare_to_wait(&cmd->wait_queue, &wait, TASK_INTERRUPTIBLE);
+    // Sleep until the condition is true or the timeout expires
+    unsigned long timeout = msecs_to_jiffies(COMMAND_TIMEOUT_SECONDS * 1000);
+    schedule_timeout(timeout);
+
+    finish_wait(&cmd->wait_queue, &wait);
+
+    if (cmd->answer == NULL)
+    {
+        printk(KERN_ERR "wasm: command answer timeout");
+
+        cmd->answer = kmalloc(sizeof(struct command_answer), GFP_KERNEL);
+        cmd->answer->error = kmalloc(strlen("timeout") + 1, GFP_KERNEL);
+        strcpy(cmd->answer->error, "timeout");
+    }
+
+    spin_lock_irqsave(&command_list_lock, command_list_lock_flags);
+    list_del(&cmd->list);
+    spin_unlock_irqrestore(&command_list_lock, command_list_lock_flags);
+
+    return cmd->answer;
 }
 
 // create a function to get a command from the list (called from the driver), locked with a mutex
@@ -69,6 +139,7 @@ static struct command *get_command(void)
     {
         cmd = list_first_entry(&command_list, struct command, list);
         list_del(&cmd->list);
+        list_add_tail(&cmd->list, &in_flight_command_list);
     }
     spin_unlock_irqrestore(&command_list_lock, command_list_lock_flags);
 
@@ -272,6 +343,50 @@ int parse_json_from_buffer(void)
                 goto cleanup;
             }
         }
+        else if (strcmp("answer", command) == 0)
+        {
+            printk("wasm: command answer parsing");
+
+            int command_id = json_object_get_number(root, "id");
+
+            struct command *cmd = lookup_in_flight_command(command_id);
+
+            if (cmd == NULL)
+            {
+                printk(KERN_ERR "wasm: command %d not found", command_id);
+                status = -1;
+                goto cleanup;
+            }
+
+            struct command_answer *cmd_answer = kmalloc(sizeof(struct command_answer), GFP_KERNEL);
+            char *answer = json_object_get_string(root, "answer");
+            char *error = json_object_get_string(root, "error");
+
+            printk("wasm: answer: %s, error: %s", answer, error);
+
+            if (error)
+            {
+                cmd_answer->error = kmalloc(strlen(error) + 1, GFP_KERNEL);
+                strcpy(cmd_answer->error, error);
+            }
+            else
+            {
+                cmd_answer->error = NULL;
+            }
+
+            if (answer)
+            {
+                cmd_answer->answer = kmalloc(strlen(answer) + 1, GFP_KERNEL);
+                strcpy(cmd_answer->answer, answer);
+            }
+            else
+            {
+                cmd_answer->answer = NULL;
+            }
+
+            cmd->answer = cmd_answer;
+            wake_up_interruptible(&cmd->wait_queue);
+        }
         else if (strcmp("proxywasm_test", command) == 0)
         {
             // TODO test only
@@ -362,7 +477,7 @@ static ssize_t device_read(struct file *file,   /* see include/linux/fs.h   */
 
     // copy the command to the buffer
     int bytes_read = 0;
-    int bytes_to_read = c->size; //min(length, c->size - *offset);
+    int bytes_to_read = c->size; // min(length, c->size - *offset);
     if (bytes_to_read > 0)
     {
         // if (copy_to_user(buffer, c->data + *offset, bytes_to_read))
@@ -377,12 +492,12 @@ static ssize_t device_read(struct file *file,   /* see include/linux/fs.h   */
         // *offset += bytes_to_read;
     }
 
-    // if (*offset >= c->size)
-    {
-        // free the command
-        kfree(c->data);
-        kfree(c);
-    }
+    // // if (*offset >= c->size)
+    // {
+    //     // free the command
+    //     kfree(c->data);
+    //     kfree(c);
+    // }
 
     return bytes_read;
 }
@@ -399,10 +514,10 @@ static ssize_t device_write(struct file *file, const char *buffer, size_t length
     else
         bytes_to_write = maxbytes;
 
-    bytes_writen = bytes_to_write - copy_from_user(device_buffer + *offset, buffer, bytes_to_write);
+    bytes_writen = bytes_to_write - copy_from_user(device_buffer + device_buffer_size, buffer, bytes_to_write);
     printk(KERN_INFO "wasm: device has been written %d", bytes_writen);
     *offset += bytes_writen;
-    device_buffer_size = *offset;
+    device_buffer_size += bytes_writen;
 
     // search for the end of the string in device_buffer
     for (;;)

--- a/device_driver.c
+++ b/device_driver.c
@@ -492,13 +492,6 @@ static ssize_t device_read(struct file *file,   /* see include/linux/fs.h   */
         // *offset += bytes_to_read;
     }
 
-    // // if (*offset >= c->size)
-    // {
-    //     // free the command
-    //     kfree(c->data);
-    //     kfree(c);
-    // }
-
     return bytes_read;
 }
 

--- a/device_driver.h
+++ b/device_driver.h
@@ -29,7 +29,7 @@ typedef struct command_answer
 
 void free_command_answer(command_answer *cmd_answer);
 
-command_answer *send_command(char *name, char *data, size_t data_size);
+command_answer *send_command(char *name, char *data);
 wasm_vm_result load_module(char *name, char *code, unsigned length, char *entrypoint);
 
 #define SUCCESS 0

--- a/device_driver.h
+++ b/device_driver.h
@@ -21,7 +21,14 @@ static int device_release(struct inode *, struct file *);
 static ssize_t device_read(struct file *, char __user *, size_t, loff_t *);
 static ssize_t device_write(struct file *, const char __user *, size_t, loff_t *);
 
-void send_command(char *data, size_t size);
+typedef struct command_answer {
+    char *error;
+    char *answer;
+} command_answer;
+
+void free_command_answer(command_answer *cmd_answer);
+
+command_answer *send_command(char *data, size_t size);
 wasm_vm_result load_module(char *name, char *code, unsigned length, char *entrypoint);
 
 #define SUCCESS 0

--- a/device_driver.h
+++ b/device_driver.h
@@ -29,7 +29,7 @@ typedef struct command_answer
 
 void free_command_answer(command_answer *cmd_answer);
 
-command_answer *send_command(char *data, size_t size);
+command_answer *send_command(char *name, char *data, size_t data_size);
 wasm_vm_result load_module(char *name, char *code, unsigned length, char *entrypoint);
 
 #define SUCCESS 0

--- a/device_driver.h
+++ b/device_driver.h
@@ -2,9 +2,9 @@
  * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: MIT OR GPL-2.0-only
- * 
+ *
  * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
- * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied, 
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
  * modified, or distributed except according to those terms.
  */
 
@@ -21,7 +21,8 @@ static int device_release(struct inode *, struct file *);
 static ssize_t device_read(struct file *, char __user *, size_t, loff_t *);
 static ssize_t device_write(struct file *, const char __user *, size_t, loff_t *);
 
-typedef struct command_answer {
+typedef struct command_answer
+{
     char *error;
     char *answer;
 } command_answer;

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -523,20 +523,20 @@ wasm_vm_result proxywasm_destroy_context(proxywasm *p)
 {
     wasm_vm_result result;
     proxywasm_filter *f;
-    // for (f = p->filters; f != NULL; f = f->next)
-    // {
-    //     result = wasm_vm_call_direct(p->vm, f->proxy_on_done, p->current_context->id);
-    //     if (result.err != NULL)
-    //     {
-    //         pr_err("wasm: Calling filter %s.proxy_on_done errored %s\n", f->name, result.err);
-    //     }
+    for (f = p->filters; f != NULL; f = f->next)
+    {
+        result = wasm_vm_call_direct(p->vm, f->proxy_on_done, p->current_context->id);
+        if (result.err != NULL)
+        {
+            pr_err("wasm: Calling filter %s.proxy_on_done errored %s\n", f->name, result.err);
+        }
 
-    //     result = wasm_vm_call_direct(p->vm, f->proxy_on_delete, p->current_context->id);
-    //     if (result.err != NULL)
-    //     {
-    //         pr_err("wasm: Calling filter %s.proxy_on_delete errored %s\n", f->name, result.err);
-    //     }
-    // }
+        result = wasm_vm_call_direct(p->vm, f->proxy_on_delete, p->current_context->id);
+        if (result.err != NULL)
+        {
+            pr_err("wasm: Calling filter %s.proxy_on_delete errored %s\n", f->name, result.err);
+        }
+    }
 
     free_proxywasm_context(p->current_context);
 

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -523,20 +523,20 @@ wasm_vm_result proxywasm_destroy_context(proxywasm *p)
 {
     wasm_vm_result result;
     proxywasm_filter *f;
-    for (f = p->filters; f != NULL; f = f->next)
-    {
-        result = wasm_vm_call_direct(p->vm, f->proxy_on_done, p->current_context->id);
-        if (result.err != NULL)
-        {
-            pr_err("wasm: Calling filter %s.proxy_on_done errored %s\n", f->name, result.err);
-        }
+    // for (f = p->filters; f != NULL; f = f->next)
+    // {
+    //     result = wasm_vm_call_direct(p->vm, f->proxy_on_done, p->current_context->id);
+    //     if (result.err != NULL)
+    //     {
+    //         pr_err("wasm: Calling filter %s.proxy_on_done errored %s\n", f->name, result.err);
+    //     }
 
-        result = wasm_vm_call_direct(p->vm, f->proxy_on_delete, p->current_context->id);
-        if (result.err != NULL)
-        {
-            pr_err("wasm: Calling filter %s.proxy_on_delete errored %s\n", f->name, result.err);
-        }
-    }
+    //     result = wasm_vm_call_direct(p->vm, f->proxy_on_delete, p->current_context->id);
+    //     if (result.err != NULL)
+    //     {
+    //         pr_err("wasm: Calling filter %s.proxy_on_delete errored %s\n", f->name, result.err);
+    //     }
+    // }
 
     free_proxywasm_context(p->current_context);
 

--- a/socket.c
+++ b/socket.c
@@ -602,7 +602,7 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 
 		// Sample how to send a command to the userspace agent
 		const char *data = "{\"port\": \"8000\"}";
-		command_answer *answer = send_command("accept", data, strlen(data));
+		command_answer *answer = send_command("accept", data);
 
 		if (answer->error)
 		{

--- a/socket.c
+++ b/socket.c
@@ -602,7 +602,18 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 
 		// Sample how to send a command to the userspace agent
 		const char *command = "{\"command\": \"accept\", \"name\": \"8000\"}";
-		send_command(command, strlen(command));
+		command_answer *answer = send_command(command, strlen(command));
+
+		if (answer->error)
+		{
+			pr_err("wasm_accept: failed to send command: %s", answer->error);
+		}
+		else
+		{
+			pr_info("wasm_accept: command answer: %s", answer->answer);
+		}
+
+		free_command_answer(answer);
 
 		/*
 		 * Initialise the context with the cipher suites and

--- a/socket.c
+++ b/socket.c
@@ -601,8 +601,8 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 		proxywasm_unlock(p);
 
 		// Sample how to send a command to the userspace agent
-		const char *command = "{\"command\": \"accept\", \"name\": \"8000\"}";
-		command_answer *answer = send_command(command, strlen(command));
+		const char *data = "{\"port\": \"8000\"}";
+		command_answer *answer = send_command("accept", data, strlen(data));
 
 		if (answer->error)
 		{


### PR DESCRIPTION
## Description

Command sending is implemented now in a synchronous fashion with the external user-space agent. There is a 5 second timeout of waiting for command answers.

See https://github.com/cisco-open/wasm-kernel-module-cli/pull/11

Usage:

```bash
# Load the kernel module, then:
cd wasm-kernel-module-cli
make build-cli
lima sudo ./w3k server
```

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
