### PR TITLE
Generate CSR using wasm module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ wasm-objs :=  third-party/wasm3/source/m3_api_libc.o \
 			  main.o \
 			  netfilter.o \
 			  hashtable.o \
+			  csr.o \
 			  runtime.o \
 			  worker_thread.o \
 			  opa.o \

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ wasm-objs :=  third-party/wasm3/source/m3_api_libc.o \
 			  netfilter.o \
 			  hashtable.o \
 			  csr.o \
+			  rsa_tools.o \
 			  runtime.o \
 			  worker_thread.o \
 			  opa.o \

--- a/csr.c
+++ b/csr.c
@@ -31,7 +31,7 @@ wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
 error:
     if (result.err)
     {
-        FATAL("csr_module function lookups failed for module %s failed: %s -> %s", module->name, result.err, wasm_vm_last_error(vm));
+        FATAL("csr_module function lookups failed for module %s failed: %s -> %s", module->name, result.err, wasm_vm_last_error(module));
         return result;
     }
 

--- a/csr.c
+++ b/csr.c
@@ -1,4 +1,3 @@
-#include <linux/slab.h>
 #include "csr.h"
 
 typedef struct csr_module

--- a/csr.c
+++ b/csr.c
@@ -22,7 +22,7 @@ wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
 {
     csr_module *csr = csr_modules[vm->cpu];
     if (csr == NULL) {
-        csr_module *csr = kzalloc(sizeof(struct csr_module), GFP_KERNEL);
+        csr = kzalloc(sizeof(struct csr_module), GFP_KERNEL);
         csr->vm = vm;
         csr_modules[vm->cpu] = csr;
     }

--- a/csr.c
+++ b/csr.c
@@ -3,15 +3,31 @@
 
 typedef struct csr_module
 {
-wasm_vm_function *gen_csr;
+    wasm_vm *vm;
+
+    wasm_vm_function *generate_csr;
 }csr_module;
+
+static csr_module *csr_modules[NR_CPUS] = {0};
+
+csr_module* this_cpu_csr(void)
+{
+    int cpu = get_cpu();
+    put_cpu();
+    return csr_modules[cpu];
+}
+
 
 wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
 {
+    csr_module *csr = csr_modules[vm->cpu];
+    if (csr == NULL) {
+        csr_module *csr = kzalloc(sizeof(struct csr_module), GFP_KERNEL);
+        csr->vm = vm;
+        csr_modules[vm->cpu] = csr;
+    }
     wasm_vm_result result;
-    csr_module *csr = kzalloc(sizeof(csr_module), GFP_KERNEL);
-
-    wasm_vm_try_get_function(csr->gen_csr, wasm_vm_get_function(vm, module->name, "gen_csr"));
+    wasm_vm_try_get_function(csr->generate_csr, wasm_vm_get_function(vm, module->name, "gen_csr"));
 
 error:
     if (result.err)
@@ -23,8 +39,8 @@ error:
     return (wasm_vm_result){.err = NULL};
 }
 
-wasm_vm_result gen_csr(wasm_vm *vm, i32 priv_key_buff_ptr, i32 priv_key_buff_len) {
-    wasm_vm_result result = wasm_vm_call_direct(vm, gen_csr, priv_key_buff_ptr, priv_key_buff_len);
+wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len) {
+    wasm_vm_result result = wasm_vm_call_direct(csr->vm, csr->generate_csr, priv_key_buff_ptr, priv_key_buff_len);
     if (result.err != NULL)
     {
         pr_err("wasm: calling gen_csr errored %s\n", result.err);

--- a/csr.c
+++ b/csr.c
@@ -1,0 +1,35 @@
+#include <linux/slab.h>
+#include "csr.h"
+
+typedef struct csr_module
+{
+wasm_vm_function *gen_csr;
+}csr_module;
+
+wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
+{
+    wasm_vm_result result;
+    csr_module *csr = kzalloc(sizeof(csr_module), GFP_KERNEL);
+
+    wasm_vm_try_get_function(csr->gen_csr, wasm_vm_get_function(vm, module->name, "gen_csr"));
+
+error:
+    if (result.err)
+    {
+        FATAL("csr_module function lookups failed for module %s failed: %s -> %s", module->name, result.err, wasm_vm_last_error(vm));
+        return result;
+    }
+
+    return (wasm_vm_result){.err = NULL};
+}
+
+wasm_vm_result gen_csr(wasm_vm *vm, i32 priv_key_buff_ptr, i32 priv_key_buff_len) {
+    wasm_vm_result result = wasm_vm_call_direct(vm, gen_csr, priv_key_buff_ptr, priv_key_buff_len);
+    if (result.err != NULL)
+    {
+        pr_err("wasm: calling gen_csr errored %s\n", result.err);
+        return result;
+    }
+    printk("wasm: result of calling gen_csr %d\n", result.data->i32);
+    return result;
+}

--- a/csr.c
+++ b/csr.c
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
 #include "csr.h"
 
 typedef struct csr_module

--- a/csr.c
+++ b/csr.c
@@ -44,7 +44,7 @@ wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
         csr_modules[vm->cpu] = csr;
     }
     wasm_vm_result result;
-    wasm_vm_try_get_function(csr->generate_csr, wasm_vm_get_function(vm, module->name, "gen_csr"));
+    wasm_vm_try_get_function(csr->generate_csr, wasm_vm_get_function(vm, module->name, "csr_gen"));
     wasm_vm_try_get_function(csr->csr_malloc, wasm_vm_get_function(vm, module->name, "csr_malloc"));
     wasm_vm_try_get_function(csr->csr_free, wasm_vm_get_function(vm, module->name, "csr_free"));
 
@@ -68,14 +68,14 @@ wasm_vm_result csr_free(csr_module *csr, i32 ptr)
     return wasm_vm_call_direct(csr->vm, csr->csr_free, ptr);
 }
 
-wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len)
+wasm_vm_result csr_gen(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len)
 {
     wasm_vm_result result = wasm_vm_call_direct(csr->vm, csr->generate_csr, priv_key_buff_ptr, priv_key_buff_len);
     if (result.err != NULL)
     {
-        pr_err("wasm: calling gen_csr errored %s\n", result.err);
+        pr_err("wasm: calling csr_gen errored %s\n", result.err);
         return result;
     }
-    printk("wasm: result of calling gen_csr %d\n", result.data->i32);
+    printk("wasm: result of calling csr_gen %d\n", result.data->i32);
     return result;
 }

--- a/csr.c
+++ b/csr.c
@@ -76,6 +76,6 @@ wasm_vm_result csr_gen(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff
         pr_err("wasm: calling csr_gen errored %s\n", result.err);
         return result;
     }
-    printk("wasm: result of calling csr_gen %d\n", result.data->i32);
+    printk("wasm: result of calling csr_gen %d\n", result.data->i64);
     return result;
 }

--- a/csr.c
+++ b/csr.c
@@ -61,7 +61,7 @@ wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff
     wasm_vm_result result = wasm_vm_call_direct(csr->vm, csr->generate_csr, priv_key_buff_ptr, priv_key_buff_len);
     if (result.err != NULL)
     {
-        pr_err("wasm: calling gen_csr errored %s\n", wasm_vm_last_error(csr->generate_csr->module));
+        pr_err("wasm: calling gen_csr errored %s\n", result.err);
         return result;
     }
     printk("wasm: result of calling gen_csr %d\n", result.data->i32);

--- a/csr.c
+++ b/csr.c
@@ -36,12 +36,12 @@ void csr_unlock(csr_module *csr)
 
 wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
 {
-    csr_module *csr = csr_modules[vm->cpu];
+    csr_module *csr = csr_modules[wasm_vm_cpu(vm)];
     if (csr == NULL)
     {
         csr = kzalloc(sizeof(struct csr_module), GFP_KERNEL);
         csr->vm = vm;
-        csr_modules[vm->cpu] = csr;
+        csr_modules[wasm_vm_cpu(vm)] = csr;
     }
     wasm_vm_result result;
     wasm_vm_try_get_function(csr->generate_csr, wasm_vm_get_function(vm, module->name, "csr_gen"));

--- a/csr.c
+++ b/csr.c
@@ -61,7 +61,7 @@ wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff
     wasm_vm_result result = wasm_vm_call_direct(csr->vm, csr->generate_csr, priv_key_buff_ptr, priv_key_buff_len);
     if (result.err != NULL)
     {
-        pr_err("wasm: calling gen_csr errored %s\n", result.err);
+        pr_err("wasm: calling gen_csr errored %s\n", wasm_vm_last_error(csr->generate_csr->module));
         return result;
     }
     printk("wasm: result of calling gen_csr %d\n", result.data->i32);

--- a/csr.c
+++ b/csr.c
@@ -35,8 +35,8 @@ wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module)
     }
     wasm_vm_result result;
     wasm_vm_try_get_function(csr->generate_csr, wasm_vm_get_function(vm, module->name, "gen_csr"));
-    wasm_vm_try_get_function(csr->csr_malloc, wasm_vm_get_function(vm, module->name, "malloc"));
-    wasm_vm_try_get_function(csr->csr_free, wasm_vm_get_function(vm, module->name, "free"));
+    wasm_vm_try_get_function(csr->csr_malloc, wasm_vm_get_function(vm, module->name, "csr_malloc"));
+    wasm_vm_try_get_function(csr->csr_free, wasm_vm_get_function(vm, module->name, "csr_free"));
 
 error:
     if (result.err)

--- a/csr.h
+++ b/csr.h
@@ -4,5 +4,7 @@
 
 typedef struct csr_module csr_module;
 
+csr_module *this_cpu_csr(void);
+
 wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
-wasm_vm_result gen_csr(wasm_vm *vm, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
+wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);

--- a/csr.h
+++ b/csr.h
@@ -1,0 +1,8 @@
+#include "runtime.h"
+
+#define CSR_MODULE "csr"
+
+typedef struct csr_module csr_module;
+
+wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
+wasm_vm_result gen_csr(wasm_vm *vm, i32 priv_key_buff_ptr, i32 priv_key_buff_len);

--- a/csr.h
+++ b/csr.h
@@ -8,3 +8,5 @@ csr_module *this_cpu_csr(void);
 
 wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
 wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
+wasm_vm_result csr_malloc(csr_module *csr, i32 size);
+wasm_vm_module* get_csr_module(csr_module *csr);

--- a/csr.h
+++ b/csr.h
@@ -7,8 +7,9 @@ typedef struct csr_module csr_module;
 csr_module *this_cpu_csr(void);
 
 wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
-wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
+wasm_vm_result csr_gen(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
 wasm_vm_result csr_malloc(csr_module *csr, i32 size);
+wasm_vm_result csr_free(csr_module *csr, i32 ptr);
 wasm_vm_module* get_csr_module(csr_module *csr);
 void csr_lock(csr_module *csr);
 void csr_unlock(csr_module *csr);

--- a/csr.h
+++ b/csr.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
 #include "runtime.h"
 
 #define CSR_MODULE "csr"

--- a/csr.h
+++ b/csr.h
@@ -10,3 +10,5 @@ wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
 wasm_vm_result gen_csr(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
 wasm_vm_result csr_malloc(csr_module *csr, i32 size);
 wasm_vm_module* get_csr_module(csr_module *csr);
+void csr_lock(csr_module *csr);
+void csr_unlock(csr_module *csr);

--- a/csr.h
+++ b/csr.h
@@ -10,6 +10,6 @@ wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
 wasm_vm_result csr_gen(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
 wasm_vm_result csr_malloc(csr_module *csr, i32 size);
 wasm_vm_result csr_free(csr_module *csr, i32 ptr);
-wasm_vm_module* get_csr_module(csr_module *csr);
+wasm_vm_module *get_csr_module(csr_module *csr);
 void csr_lock(csr_module *csr);
 void csr_unlock(csr_module *csr);

--- a/device_driver.c
+++ b/device_driver.c
@@ -17,6 +17,7 @@
 #include "json.h"
 #include "opa.h"
 #include "proxywasm.h"
+#include "csr.h"
 #include "runtime.h"
 
 /* Global variables are declared as static, so are global within the file. */
@@ -305,13 +306,24 @@ wasm_vm_result load_module(char *name, char *code, unsigned length, char *entryp
                 return result;
             }
         }
-        else if (strstr(name, "proxywasm") != NULL)
+        else if (strstr(name, PROXY_WASM) != NULL)
         {
             printk("wasm: initializing proxywasm for %s", name);
             result = init_proxywasm_for(vm, module);
             if (result.err)
             {
                 FATAL("init_proxywasm_for: %s", result.err);
+                wasm_vm_unlock(vm);
+                return result;
+            }
+        }
+        else if (strstr(name, CSR_MODULE) != NULL)
+        {
+            printk("wasm: initializing csr module for %s", name);
+            result = init_csr_for(vm, module);
+            if (result.err)
+            {
+                FATAL("init_csr_for: %s", result.err);
                 wasm_vm_unlock(vm);
                 return result;
             }

--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@
 #include "socket.h"
 
 #include "filter_stats.h"
+#include "module_csr.h"
 #include "filter_tcp_metadata.h"
 
 MODULE_AUTHOR("Cisco Systems");
@@ -96,6 +97,13 @@ static int __init wasm_init(void)
         if (result.err)
         {
             FATAL("load_module -> proxywasm_stats_filter: %s", result.err);
+            return -1;
+        }
+
+        result = load_module("csr_module", module_csr, size_module_csr, "_start");
+        if (result.err)
+        {
+            FATAL("load_module -> csr_gen_filter: %s", result.err);
             return -1;
         }
     }

--- a/main.c
+++ b/main.c
@@ -100,7 +100,7 @@ static int __init wasm_init(void)
             return -1;
         }
 
-        result = load_module("csr_module", module_csr, size_module_csr, "_start");
+        result = load_module("csr_module", module_csr, size_module_csr, NULL);
         if (result.err)
         {
             FATAL("load_module -> csr_gen_filter: %s", result.err);

--- a/main.c
+++ b/main.c
@@ -100,7 +100,7 @@ static int __init wasm_init(void)
             return -1;
         }
 
-        result = load_module("csr_module", module_csr, size_module_csr, NULL);
+        result = load_module("csr_module", module_csr, size_module_csr, "_start");
         if (result.err)
         {
             FATAL("load_module -> csr_gen_filter: %s", result.err);

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -447,7 +447,7 @@ wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module)
 
     strcpy(filter->name, module->name);
 
-    wasm_vm_try_get_function(filter->proxy_on_memory_allocate, wasm_vm_get_function(vm, module->name, "malloc")); // ???? proxy_on_memory_allocate?
+    wasm_vm_try_get_function(filter->proxy_on_memory_allocate, wasm_vm_get_function(vm, module->name, "malloc"));
     wasm_vm_try_get_function(filter->proxy_on_context_create, wasm_vm_get_function(vm, module->name, "proxy_on_context_create"));
     wasm_vm_try_get_function(filter->proxy_on_new_connection, wasm_vm_get_function(vm, module->name, "proxy_on_new_connection"));
     wasm_vm_try_get_function(filter->proxy_on_vm_start, wasm_vm_get_function(vm, module->name, "proxy_on_vm_start"));

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -13,6 +13,8 @@
 
 #include "runtime.h"
 
+#define PROXY_WASM "proxywasm"
+
 typedef enum
 {
   WasmResult_Ok = 0,

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -1,0 +1,47 @@
+#include "rsa_tools.h"
+
+static br_hmac_drbg_context hmac_drbg_ctx;
+
+
+//BearSSL RSA Keygen related functions
+//Initialize BearSSL random number generator with a unix getrandom backed seeder
+void init_rnd_gen() 
+{
+
+	br_prng_seeder seeder;
+
+	seeder = br_prng_seeder_system(NULL);
+
+	br_hmac_drbg_init(&hmac_drbg_ctx, &br_sha256_vtable, NULL, 0);
+	if (!seeder(&hmac_drbg_ctx.vtable)) {
+		printk(KERN_ERR "system source of randomness failed");
+	}
+}
+// BearSSL RSA Keygen related functions
+// Generates a 2048 bit long rsa key pair
+uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub)
+{
+    br_rsa_keygen rsa_keygen = br_rsa_keygen_get_default();
+
+    unsigned char raw_priv_key[BR_RSA_KBUF_PRIV_SIZE(2048)];
+    unsigned char raw_pub_key[BR_RSA_KBUF_PUB_SIZE(2048)];
+
+
+    uint32_t result = rsa_keygen(&hmac_drbg_ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, 2048, 3);
+    return result;
+}
+
+// BearSSL RSA Keygen related functions
+// Encodes rsa private key to pkcs8 der format and returns it's lenght.
+// If the der parameter is set to NULL then it computes only the length
+size_t encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub)
+{
+    br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
+    unsigned char priv_exponent[256];
+    size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, rsa_priv, 3);
+    if (rsa_pub->nlen != priv_exponent_size) {
+        printk("Error happened during priv_exponent generation");
+    }
+    size_t len = br_encode_rsa_pkcs8_der(der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);
+    return len;
+}

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -1,5 +1,7 @@
 #include "rsa_tools.h"
 
+#include "linux/kernel.h"
+
 static br_hmac_drbg_context hmac_drbg_ctx;
 
 

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -4,20 +4,20 @@
 
 static br_hmac_drbg_context hmac_drbg_ctx;
 
-
-//BearSSL RSA Keygen related functions
-//Initialize BearSSL random number generator with a unix getrandom backed seeder
-void init_rnd_gen() 
+// BearSSL RSA Keygen related functions
+// Initialize BearSSL random number generator with a unix getrandom backed seeder
+void init_rnd_gen()
 {
 
-	br_prng_seeder seeder;
+    br_prng_seeder seeder;
 
-	seeder = br_prng_seeder_system(NULL);
+    seeder = br_prng_seeder_system(NULL);
 
-	br_hmac_drbg_init(&hmac_drbg_ctx, &br_sha256_vtable, NULL, 0);
-	if (!seeder(&hmac_drbg_ctx.vtable)) {
-		printk(KERN_ERR "system source of randomness failed");
-	}
+    br_hmac_drbg_init(&hmac_drbg_ctx, &br_sha256_vtable, NULL, 0);
+    if (!seeder(&hmac_drbg_ctx.vtable))
+    {
+        printk(KERN_ERR "system source of randomness failed");
+    }
 }
 // BearSSL RSA Keygen related functions
 // Generates a 2048 bit long rsa key pair
@@ -27,7 +27,6 @@ uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_
 
     unsigned char raw_priv_key[BR_RSA_KBUF_PRIV_SIZE(2048)];
     unsigned char raw_pub_key[BR_RSA_KBUF_PUB_SIZE(2048)];
-
 
     uint32_t result = rsa_keygen(&hmac_drbg_ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, 2048, 3);
     return result;
@@ -41,7 +40,8 @@ size_t encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_pr
     br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
     unsigned char priv_exponent[256];
     size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, rsa_priv, 3);
-    if (rsa_pub->nlen != priv_exponent_size) {
+    if (rsa_pub->nlen != priv_exponent_size)
+    {
         printk("Error happened during priv_exponent generation");
     }
     size_t len = br_encode_rsa_pkcs8_der(der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -6,7 +6,7 @@ static br_hmac_drbg_context hmac_drbg_ctx;
 
 // BearSSL RSA Keygen related functions
 // Initialize BearSSL random number generator with a unix getrandom backed seeder
-void init_rnd_gen()
+int init_rnd_gen()
 {
 
     br_prng_seeder seeder;
@@ -17,7 +17,9 @@ void init_rnd_gen()
     if (!seeder(&hmac_drbg_ctx.vtable))
     {
         printk(KERN_ERR "system source of randomness failed");
+        return -1;
     }
+    return 0;
 }
 // BearSSL RSA Keygen related functions
 // Generates a 2048 bit long rsa key pair

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -28,8 +28,7 @@ uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_
     unsigned char raw_priv_key[BR_RSA_KBUF_PRIV_SIZE(2048)];
     unsigned char raw_pub_key[BR_RSA_KBUF_PUB_SIZE(2048)];
 
-    uint32_t result = rsa_keygen(&hmac_drbg_ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, 2048, 3);
-    return result;
+    return rsa_keygen(&hmac_drbg_ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, 2048, 3);
 }
 
 // BearSSL RSA Keygen related functions
@@ -44,6 +43,5 @@ size_t encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_pr
     {
         printk("Error happened during priv_exponent generation");
     }
-    size_t len = br_encode_rsa_pkcs8_der(der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);
-    return len;
+    return br_encode_rsa_pkcs8_der(der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);
 }

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
 #include "rsa_tools.h"
 
 #include "linux/kernel.h"

--- a/rsa_tools.h
+++ b/rsa_tools.h
@@ -1,0 +1,5 @@
+#include "bearssl.h"
+
+void init_rnd_gen(void);
+uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub);
+size_t encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub);

--- a/rsa_tools.h
+++ b/rsa_tools.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
 #include "bearssl.h"
 
 int init_rnd_gen(void);

--- a/rsa_tools.h
+++ b/rsa_tools.h
@@ -1,5 +1,5 @@
 #include "bearssl.h"
 
-void init_rnd_gen(void);
+int init_rnd_gen(void);
 uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub);
 size_t encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub);

--- a/runtime.c
+++ b/runtime.c
@@ -445,7 +445,8 @@ typedef struct __wasi_ciovec_t {
 const void* copy_iov_to_host(IM3Runtime runtime, void* _mem, __wasi_ciovec_t* host_iov, __wasi_iovec_t* wasi_iov, int32_t iovs_len)
 {
     // Convert wasi memory offsets to host addresses
-    for (int i = 0; i < iovs_len; i++) {
+    int i;
+    for (i = 0; i < iovs_len; i++) {
         host_iov[i].buf = m3ApiOffsetToPtr(wasi_iov[i].buf);
         host_iov[i].buf_len  = wasi_iov[i].buf_len;
         m3ApiCheckMem(host_iov[i].buf,     host_iov[i].buf_len);

--- a/runtime.c
+++ b/runtime.c
@@ -429,6 +429,30 @@ m3ApiRawFunction(m3_ext_submit_metric)
     m3ApiReturn(i_size);
 }
 
+typedef struct __wasi_ciovec_t {
+    /**
+     * The address of the buffer to be written.
+     */
+    const uint8_t * buf;
+
+    /**
+     * The length of the buffer to be written.
+     */
+    uint32_t buf_len;
+
+} __wasi_ciovec_t;
+
+m3ApiRawFunction(m3_wasi_generic_fd_write)
+{  
+    m3ApiReturnType(uint16_t);
+    m3ApiGetArg(uint32_t             , fd);
+    m3ApiGetArgMem(__wasi_ciovec_t * , iovs);
+    m3ApiGetArg(size_t               , iovs_len);
+    m3ApiGetArgMem(uint32_t *        , nwritten);
+
+    m3ApiReturn(0);
+}
+
 m3ApiRawFunction(m3_wasi_generic_environ_get)
 {
     m3ApiReturnType  (uint32_t)
@@ -493,6 +517,7 @@ static M3Result m3_LinkWASIMocks(IM3Module module)
     _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_get",       "i(**)", m3_wasi_generic_environ_get)));
     _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "environ_sizes_get", "i(**)", m3_wasi_generic_environ_sizes_get)));
     _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "proc_exit",           "(i)", m3_wasi_generic_proc_exit)));
+    _(SuppressLookupFailure (m3_LinkRawFunction (module, wasi, "fd_write",        "i(i*i*)", m3_wasi_generic_fd_write)));
 
 _catch:
     return result;

--- a/socket.c
+++ b/socket.c
@@ -786,21 +786,12 @@ int wasm_socket_init(void)
 		printk("RSA keys are successfully generated.");
 	}
 
-	printk("Generating private exponent");
-	br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
-	unsigned char priv_exponent[256];
-	size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, &rsa_priv, 3);
-	if (rsa_pub.nlen != priv_exponent_size) {
-		printk("Error happened during priv_exponent generation");
-	}
+	size_t pem_len = br_pem_encode(NULL, NULL, BR_RSA_KBUF_PRIV_SIZE(2048), "RSA PRIVATE KEY", 0);
 
-	printk("Private exponent generated");
+	void *pem = kmalloc(pem_len+1, GFP_KERNEL);
+	br_pem_encode(pem, raw_priv_key, BR_RSA_KBUF_PRIV_SIZE(2048), "RSA PRIVATE KEY", 0);
 
-	// void* priv_key_in_der = kmalloc(sizeof(void*), GFP_KERNEL);
-
-	// size_t enc_key_length = br_encode_rsa_raw_der(priv_key_in_der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);
-	// printk("Private key encoded to raw der format");
-
+	printk("%s ", &pem[1]);
 
 	printk(KERN_INFO "WASM socket support loaded.");
 

--- a/socket.c
+++ b/socket.c
@@ -684,7 +684,7 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 		br_pem_encode(pem, encoded_rsa, pem_len, "RSA PRIVATE KEY", 0);
 
 
-		wasm_vm_result generated_csr = gen_csr(csr, addr, len);
+		wasm_vm_result generated_csr = gen_csr(csr, addr, pem_len+1);
 
 
 		// unsigned char *pem = kzalloc(pem_len+1, GFP_KERNEL);

--- a/socket.c
+++ b/socket.c
@@ -250,9 +250,19 @@ static void free_wasm_socket_context(wasm_socket_context *sc)
 		// 	pr_err("br_sslio_close returned an error");
 		// }
 		if (sc->direction == ListenerDirectionInbound)
+		{
 			kfree(sc->sc);
+			kfree(sc->rsa_priv);
+			kfree(sc->rsa_pub);
+			kfree(sc->cert);
+		}
 		else
+		{
 			kfree(sc->cc);
+			kfree(sc->rsa_priv);
+			kfree(sc->rsa_pub);
+			kfree(sc->cert);
+		}
 
 		// TODO free the proxywasm context
 

--- a/socket.c
+++ b/socket.c
@@ -17,8 +17,6 @@
 #include <net/sock.h>
 #include <net/ip.h>
 
-#include <linux/fs.h>
-#include <linux/slab.h>
 #include <linux/uaccess.h>
 
 #include "bearssl.h"
@@ -743,9 +741,6 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 		 * Initialise the simplified I/O wrapper context.
 		 */
 		br_sslio_init(&sc->ioc, &sc->sc->eng, sock_read, client, sock_write, client);
-
-		// We should save the ssl context here to the socket
-		sk->sk_user_data = sc;
 
 		// // We should save the ssl context here to the socket
 		client->sk_user_data = sc;

--- a/socket.c
+++ b/socket.c
@@ -668,12 +668,26 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 
 		size_t pem_len = br_pem_encode(NULL, NULL, len, "RSA PRIVATE KEY", 0);
 
-		unsigned char *pem = kzalloc(pem_len+1, GFP_KERNEL);
-		br_pem_encode(pem, encoded_rsa, len, "RSA PRIVATE KEY", 0);
-
+		//Allocate memory inside the wasm vm since this data must be available inside the module
 		csr_module *csr = this_cpu_csr();
+		wasm_vm_result malloc_result = csr_malloc(csr, pem_len+1);
+		if (malloc_result.err)
+		{
+			FATAL("csr wasm_vm_csr_malloc error: %s", malloc_result.err);
+			return 0;
+		}
+		uint8_t *mem = wasm_vm_memory(get_csr_module(csr));
+		i32 addr = malloc_result.data->i32;
+
+		unsigned char *pem = mem + addr;
+
+		br_pem_encode(pem, encoded_rsa, pem_len, "RSA PRIVATE KEY", 0);
+
 
 		wasm_vm_result generated_csr = gen_csr(csr, pem, len);
+
+
+		// unsigned char *pem = kzalloc(pem_len+1, GFP_KERNEL);
 
 		/*
 		 * Initialise the context with the cipher suites and

--- a/socket.c
+++ b/socket.c
@@ -684,7 +684,7 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 		br_pem_encode(pem, encoded_rsa, pem_len, "RSA PRIVATE KEY", 0);
 
 
-		wasm_vm_result generated_csr = gen_csr(csr, pem, len);
+		wasm_vm_result generated_csr = gen_csr(csr, addr, len);
 
 
 		// unsigned char *pem = kzalloc(pem_len+1, GFP_KERNEL);

--- a/socket.c
+++ b/socket.c
@@ -753,38 +753,6 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 	return ret;
 }
 
-static size_t
-hextobin(unsigned char *dst, const char *src)
-{
-	size_t num;
-	unsigned acc;
-	int z;
-
-	num = 0;
-	z = 0;
-	acc = 0;
-	while (*src != 0) {
-		int c = *src ++;
-		if (c >= '0' && c <= '9') {
-			c -= '0';
-		} else if (c >= 'A' && c <= 'F') {
-			c -= ('A' - 10);
-		} else if (c >= 'a' && c <= 'f') {
-			c -= ('a' - 10);
-		} else {
-			continue;
-		}
-		if (z) {
-			*dst ++ = (acc << 4) + c;
-			num ++;
-		} else {
-			acc = c;
-		}
-		z = !z;
-	}
-	return num;
-}
-
 int wasm_socket_init(void)
 {
 	// let's overwrite tcp_port with our own implementation
@@ -801,40 +769,37 @@ int wasm_socket_init(void)
 	wasm_prot.destroy = wasm_destroy;
 
 	br_hmac_drbg_context ctx;
-	unsigned char seed[42];
-	size_t seed_len;
-
-	seed_len = hextobin(seed,
-		"009A4D6792295A7F730FC3F2B49CBC0F62E862272F"
-		"01795EDF0D54DB760F156D0DAC04C0322B3A204224");
-	br_hmac_drbg_init(&ctx, &br_sha256_vtable, seed, seed_len);
+	br_hmac_drbg_init(&ctx, &br_sha256_vtable, "RSA keygen seed", 15);
 
 
 	br_rsa_keygen rsa_keygen = br_rsa_keygen_get_default();
 
-	br_rsa_private_key* rsa_priv = kmalloc(sizeof(br_rsa_private_key), GFP_KERNEL);
-	void* raw_priv_key = kmalloc(sizeof(void*), GFP_KERNEL);
+	br_rsa_private_key rsa_priv;
+	unsigned char raw_priv_key[BR_RSA_KBUF_PRIV_SIZE(2048)];
 
-	br_rsa_public_key* rsa_pub = kmalloc(sizeof(br_rsa_public_key), GFP_KERNEL);
-	void* raw_pub_key = kmalloc(sizeof(void*), GFP_KERNEL);
+	br_rsa_public_key rsa_pub;
+	unsigned char raw_pub_key[BR_RSA_KBUF_PUB_SIZE(2048)];
 
 
-	uint32_t result = rsa_keygen(&ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, 2048, 3);
+	uint32_t result = rsa_keygen(&ctx.vtable, &rsa_priv, raw_priv_key, &rsa_pub, raw_pub_key, 2048, 3);
 	if (result == 1) {
 		printk("RSA keys are successfully generated.");
 	}
 
 	printk("Generating private exponent");
 	br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
-	void* priv_exponent = kmalloc(sizeof(void*), GFP_KERNEL);
-	size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, rsa_priv, 3);
+	unsigned char priv_exponent[256];
+	size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, &rsa_priv, 3);
+	if (rsa_pub.nlen != priv_exponent_size) {
+		printk("Error happened during priv_exponent generation");
+	}
 
 	printk("Private exponent generated");
 
-	void* priv_key_in_der = kmalloc(sizeof(void*), GFP_KERNEL);
+	// void* priv_key_in_der = kmalloc(sizeof(void*), GFP_KERNEL);
 
-	size_t enc_key_length = br_encode_rsa_raw_der(priv_key_in_der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);
-	printk("Private key encoded to raw der format");
+	// size_t enc_key_length = br_encode_rsa_raw_der(priv_key_in_der, rsa_priv, rsa_pub, priv_exponent, priv_exponent_size);
+	// printk("Private key encoded to raw der format");
 
 
 	printk(KERN_INFO "WASM socket support loaded.");

--- a/socket.c
+++ b/socket.c
@@ -605,6 +605,7 @@ int (*connect)(struct sock *sk, struct sockaddr *uaddr, int addr_len);
 int	(*bind)(struct sock *sk,struct sockaddr *addr, int addr_len);
 
 int	wasm_bind(struct sock *sk,struct sockaddr *addr, int addr_len) {
+	printk("WASM BIND WAS CALLED");
 	u16 port = (u16)(sk->sk_portpair >> 16);
 	int ret = bind(sk, addr, addr_len);
 	if (ret == 0 && eval_connection(port, INPUT, current->comm)){
@@ -614,40 +615,42 @@ int	wasm_bind(struct sock *sk,struct sockaddr *addr, int addr_len) {
 		wasm_socket_context *sc = new_server_wasm_socket_context(p);
 		proxywasm_unlock(p);
 
-		csr_module *csr = this_cpu_csr();
+		sk->sk_user_data = sc;
+
+		// csr_module *csr = this_cpu_csr();
 		
-		br_rsa_keygen rsa_keygen = br_rsa_keygen_get_default();
+		// br_rsa_keygen rsa_keygen = br_rsa_keygen_get_default();
 
-		unsigned char raw_priv_key[BR_RSA_KBUF_PRIV_SIZE(2048)];
-		unsigned char raw_pub_key[BR_RSA_KBUF_PUB_SIZE(2048)];
-
-
-		uint32_t result = rsa_keygen(&hmac_drbg_ctx.vtable, sc->rsa_priv, raw_priv_key, sc->rsa_pub, raw_pub_key, 2048, 3);
-		if (result == 1) {
-			printk("RSA keys are successfully generated.");
-		}
-
-		printk("Generating private exponent");
-		br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
-		unsigned char priv_exponent[256];
-		size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, sc->rsa_priv, 3);
-		if (sc->rsa_pub->nlen != priv_exponent_size) {
-			printk("Error happened during priv_exponent generation");
-		}
-
-		size_t len = br_encode_rsa_raw_der(NULL, sc->rsa_priv, sc->rsa_pub, priv_exponent, priv_exponent_size);
-
-		unsigned char* encoded_rsa = kmalloc(len, GFP_KERNEL);
-		br_encode_rsa_raw_der(encoded_rsa, sc->rsa_priv, sc->rsa_pub, priv_exponent, priv_exponent_size);
+		// unsigned char raw_priv_key[BR_RSA_KBUF_PRIV_SIZE(2048)];
+		// unsigned char raw_pub_key[BR_RSA_KBUF_PUB_SIZE(2048)];
 
 
-		size_t pem_len = br_pem_encode(NULL, NULL, len, "RSA PRIVATE KEY", 0);
+		// uint32_t result = rsa_keygen(&hmac_drbg_ctx.vtable, sc->rsa_priv, raw_priv_key, sc->rsa_pub, raw_pub_key, 2048, 3);
+		// if (result == 1) {
+		// 	printk("RSA keys are successfully generated.");
+		// }
 
-		unsigned char *pem = kmalloc(pem_len+1, GFP_KERNEL);
-		br_pem_encode(pem, encoded_rsa, len, "RSA PRIVATE KEY", 0);
+		// printk("Generating private exponent");
+		// br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
+		// unsigned char priv_exponent[256];
+		// size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, sc->rsa_priv, 3);
+		// if (sc->rsa_pub->nlen != priv_exponent_size) {
+		// 	printk("Error happened during priv_exponent generation");
+		// }
+
+		// size_t len = br_encode_rsa_raw_der(NULL, sc->rsa_priv, sc->rsa_pub, priv_exponent, priv_exponent_size);
+
+		// unsigned char* encoded_rsa = kmalloc(len, GFP_KERNEL);
+		// br_encode_rsa_raw_der(encoded_rsa, sc->rsa_priv, sc->rsa_pub, priv_exponent, priv_exponent_size);
+
+
+		// size_t pem_len = br_pem_encode(NULL, NULL, len, "RSA PRIVATE KEY", 0);
+
+		// unsigned char *pem = kmalloc(pem_len+1, GFP_KERNEL);
+		// br_pem_encode(pem, encoded_rsa, len, "RSA PRIVATE KEY", 0);
 
 		
-		wasm_vm_result res = gen_csr(csr, pem, len);
+		// wasm_vm_result res = gen_csr(csr, pem, len);
 
 	}
 
@@ -656,6 +659,7 @@ int	wasm_bind(struct sock *sk,struct sockaddr *addr, int addr_len) {
 
 struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 {
+	printk("WASM ACCEPT WAS CALLED");
 	u16 port = (u16)(sk->sk_portpair >> 16);
 	printk("wasm_accept: app: %s on port: %d", current->comm, port);
 

--- a/socket.c
+++ b/socket.c
@@ -786,12 +786,26 @@ int wasm_socket_init(void)
 		printk("RSA keys are successfully generated.");
 	}
 
-	size_t pem_len = br_pem_encode(NULL, NULL, BR_RSA_KBUF_PRIV_SIZE(2048), "RSA PRIVATE KEY", 0);
+	printk("Generating private exponent");
+ 	br_rsa_compute_privexp rsa_priv_exp_comp = br_rsa_compute_privexp_get_default();
+ 	unsigned char priv_exponent[256];
+ 	size_t priv_exponent_size = rsa_priv_exp_comp(priv_exponent, &rsa_priv, 3);
+ 	if (rsa_pub.nlen != priv_exponent_size) {
+ 		printk("Error happened during priv_exponent generation");
+ 	}
 
-	void *pem = kmalloc(pem_len+1, GFP_KERNEL);
-	br_pem_encode(pem, raw_priv_key, BR_RSA_KBUF_PRIV_SIZE(2048), "RSA PRIVATE KEY", 0);
+	size_t len = br_encode_rsa_raw_der(NULL, &rsa_priv, &rsa_pub, priv_exponent, priv_exponent_size);
 
-	printk("%s ", &pem[1]);
+	unsigned char* encoded_rsa = kmalloc(len, GFP_KERNEL);
+	br_encode_rsa_raw_der(encoded_rsa, &rsa_priv, &rsa_pub, priv_exponent, priv_exponent_size);
+
+
+	size_t pem_len = br_pem_encode(NULL, NULL, len, "RSA PRIVATE KEY", 0);
+
+	unsigned char *pem = kmalloc(pem_len+1, GFP_KERNEL);
+	br_pem_encode(pem, encoded_rsa, len, "RSA PRIVATE KEY", 0);
+
+	printk("%s", pem);
 
 	printk(KERN_INFO "WASM socket support loaded.");
 

--- a/socket.c
+++ b/socket.c
@@ -633,18 +633,20 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 			// generating certificate signing request
 			if (sc->rsa_priv == NULL || sc->rsa_pub == NULL)
 			{
-				u_int32_t result =  generate_rsa_keys(sc->rsa_priv, sc->rsa_pub);
-				if (result == 0) {
+				u_int32_t result = generate_rsa_keys(sc->rsa_priv, sc->rsa_pub);
+				if (result == 0)
+				{
 					pr_err("wasm_accept: error generating rsa keys");
 				}
 			}
 
 			size_t len = encode_rsa_priv_key_to_der(NULL, sc->rsa_priv, sc->rsa_pub);
-			if (len == 0) {
+			if (len == 0)
+			{
 				pr_err("wasm_accept: error during rsa private key der encoding");
 			}
 
-			//Allocate memory inside the wasm vm since this data must be available inside the module
+			// Allocate memory inside the wasm vm since this data must be available inside the module
 			csr_module *csr = this_cpu_csr();
 
 			csr_lock(csr);
@@ -665,7 +667,7 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 			encode_rsa_priv_key_to_der(der, sc->rsa_priv, sc->rsa_pub);
 
 			wasm_vm_result generated_csr = csr_gen(csr, addr, len);
-		
+
 			wasm_vm_result free_result = csr_free(csr, addr);
 			if (free_result.err)
 			{
@@ -677,10 +679,9 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 			i64 csr_from_module = generated_csr.data->i64;
 
 			i32 csr_len = (i32)(csr_from_module);
-			unsigned char * csr_ptr = (i32)(csr_from_module >> 32) + mem;
+			unsigned char *csr_ptr = (i32)(csr_from_module >> 32) + mem;
 
 			csr_unlock(csr);
-
 		}
 		/*
 		 * Initialise the context with the cipher suites and
@@ -771,18 +772,20 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 			// generating certificate signing request
 			if (sc->rsa_priv == NULL || sc->rsa_pub == NULL)
 			{
-				u_int32_t result =  generate_rsa_keys(sc->rsa_priv, sc->rsa_pub);
-				if (result == 0) {
+				u_int32_t result = generate_rsa_keys(sc->rsa_priv, sc->rsa_pub);
+				if (result == 0)
+				{
 					pr_err("wasm_accept: error generating rsa keys");
 				}
 			}
 
 			size_t len = encode_rsa_priv_key_to_der(NULL, sc->rsa_priv, sc->rsa_pub);
-			if (len == 0) {
+			if (len == 0)
+			{
 				pr_err("wasm_accept: error during rsa private key der encoding");
 			}
 
-			//Allocate memory inside the wasm vm since this data must be available inside the module
+			// Allocate memory inside the wasm vm since this data must be available inside the module
 			csr_module *csr = this_cpu_csr();
 
 			csr_lock(csr);
@@ -803,7 +806,7 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 			encode_rsa_priv_key_to_der(der, sc->rsa_priv, sc->rsa_pub);
 
 			wasm_vm_result generated_csr = csr_gen(csr, addr, len);
-		
+
 			wasm_vm_result free_result = csr_free(csr, addr);
 			if (free_result.err)
 			{
@@ -815,10 +818,9 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 			i64 csr_from_module = generated_csr.data->i64;
 
 			i32 csr_len = (i32)(csr_from_module);
-			unsigned char * csr_ptr = (i32)(csr_from_module >> 32) + mem;
+			unsigned char *csr_ptr = (i32)(csr_from_module >> 32) + mem;
 
 			csr_unlock(csr);
-
 		}
 
 		/*
@@ -879,7 +881,7 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 
 int wasm_socket_init(void)
 {
-	//Initialize BearSSL random number generator
+	// Initialize BearSSL random number generator
 	init_rnd_gen();
 
 	// let's overwrite tcp_port with our own implementation

--- a/socket.c
+++ b/socket.c
@@ -665,12 +665,9 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 		unsigned char* encoded_rsa = kzalloc(len, GFP_KERNEL);
 		br_encode_rsa_raw_der(encoded_rsa, sc->rsa_priv, sc->rsa_pub, priv_exponent, priv_exponent_size);
 
-
-		size_t pem_len = br_pem_encode(NULL, NULL, len, "RSA PRIVATE KEY", 0);
-
 		//Allocate memory inside the wasm vm since this data must be available inside the module
 		csr_module *csr = this_cpu_csr();
-		wasm_vm_result malloc_result = csr_malloc(csr, pem_len+1);
+		wasm_vm_result malloc_result = csr_malloc(csr, 4096);
 		if (malloc_result.err)
 		{
 			FATAL("csr wasm_vm_csr_malloc error: %s", malloc_result.err);
@@ -681,13 +678,10 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 
 		unsigned char *pem = mem + addr;
 
-		br_pem_encode(pem, encoded_rsa, pem_len, "RSA PRIVATE KEY", 0);
-
+		size_t pem_len = br_pem_encode(pem, encoded_rsa, len, "RSA PRIVATE KEY", 0);
+		printk("PEM: %s", pem);
 
 		wasm_vm_result generated_csr = gen_csr(csr, addr, pem_len+1);
-
-
-		// unsigned char *pem = kzalloc(pem_len+1, GFP_KERNEL);
 
 		/*
 		 * Initialise the context with the cipher suites and


### PR DESCRIPTION
## Description

This PR generates a rsa keypair inside a kernel using bearSSL. The stored key will then be used to generate a certificate signing request using a wasm module. (bearSSL at the moment does not support this). This CSR will then be used in an agent code(e.g.: istio controlplane) to generate a proper certificate.

The used module can be found: https://github.com/cisco-open/wasm-kernel-module-cli/tree/main/samples/csr-rust

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
