### PR TITLE
fix iov_length query and device class_create on 6.4 kernel

### DIFF
--- a/device_driver.c
+++ b/device_driver.c
@@ -10,6 +10,7 @@
 
 #include <linux/uaccess.h>
 #include <linux/delay.h>
+#include <linux/version.h>
 #include <linux/wait.h>
 
 #include "base64.h"
@@ -210,7 +211,12 @@ int chardev_init(void)
 
     pr_info("wasm: I was assigned major number %d.", major);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     cls = class_create(THIS_MODULE, DEVICE_NAME);
+#else
+    cls = class_create(DEVICE_NAME);
+#endif
+
     device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);
 
     pr_info("wasm: Device created on /dev/%s", DEVICE_NAME);

--- a/runtime.c
+++ b/runtime.c
@@ -194,7 +194,7 @@ wasm_vm_result wasm_vm_load_module(wasm_vm *vm, const char *name, unsigned char 
         goto on_error;
     }
 
-    char *module_name = kmalloc(strlen(name), GFP_ATOMIC);
+    char *module_name = kmalloc(strlen(name) + 1, GFP_ATOMIC);
     strcpy(module_name, name);
     m3_SetModuleName(module, module_name);
 

--- a/socket.c
+++ b/socket.c
@@ -8,16 +8,13 @@
  * modified, or distributed except according to those terms.
  */
 
-#include <linux/module.h>
-#include <linux/kernel.h>
-#include <net/protocol.h>
 #include <linux/tcp.h>
 #include <linux/version.h>
+#include <linux/uaccess.h>
+#include <net/protocol.h>
 #include <net/tcp.h>
 #include <net/sock.h>
 #include <net/ip.h>
-
-#include <linux/uaccess.h>
 
 #include "bearssl.h"
 #include "device_driver.h"
@@ -371,7 +368,7 @@ void dump_msghdr(struct msghdr *msg)
 	printk(KERN_INFO "npages = %d", npages);
 
 	struct iovec *iov;
-	
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	iov = msg->msg_iter.iov;
 #else

--- a/socket.c
+++ b/socket.c
@@ -370,7 +370,15 @@ void dump_msghdr(struct msghdr *msg)
 	npages = iov_iter_npages(&msg->msg_iter, 16384);
 	printk(KERN_INFO "npages = %d", npages);
 
-	iovlen = iov_length(msg->msg_iter.iov, npages);
+	struct iovec *iov;
+	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+	iov = msg->msg_iter.iov;
+#else
+	iov = iter_iov(&msg->msg_iter);
+#endif
+
+	iovlen = iov_length(iov, npages);
 	printk(KERN_INFO "iovlen = %zd", iovlen);
 
 	len = copy_from_iter(data, iovlen - msg->msg_iter.count, &msg->msg_iter);


### PR DESCRIPTION
## Description

Things have changed in kernel 6.4, see:

- https://elixir.bootlin.com/linux/v6.4/source/include/linux/uio.h#L72
- https://elixir.bootlin.com/linux/v6.4/source/include/linux/device/class.h#L230

Also fixing an under allocation for the module name string, which only bubbled up in this kernel version.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
