### PR TITLE
socket: add missing proxywasm locking and context setting

### DIFF
--- a/proxywasm.c
+++ b/proxywasm.c
@@ -27,14 +27,14 @@
     proxywasm_filter *f;                                                                \
     for (f = p->filters; f != NULL; f = f->next)                                        \
     {                                                                                   \
-        printk("wasm: Calling filter %s\n", f->name);                                   \
+        printk("wasm: calling %s "#CALL, f->name);                               \
         result = CALL;                                                                  \
         if (result.err != NULL)                                                         \
         {                                                                               \
-            pr_err("wasm: Calling filter %s errored %s\n", f->name, result.err);        \
+            pr_err("wasm: calling %s "#CALL" error: %s\n", f->name, result.err); \
             return result;                                                              \
         }                                                                               \
-        printk("wasm: result of calling filter %s -> %d\n", f->name, result.data->i32); \
+        printk("wasm: result of calling %s "#CALL": %d", f->name, result.data->i32);   \
     }                                                                                   \
     return result;
 
@@ -528,13 +528,13 @@ wasm_vm_result proxywasm_destroy_context(proxywasm *p)
         result = wasm_vm_call_direct(p->vm, f->proxy_on_done, p->current_context->id);
         if (result.err != NULL)
         {
-            pr_err("wasm: Calling filter %s.proxy_on_done errored %s\n", f->name, result.err);
+            pr_err("wasm: calling %s.proxy_on_done errored %s", f->name, result.err);
         }
 
         result = wasm_vm_call_direct(p->vm, f->proxy_on_delete, p->current_context->id);
         if (result.err != NULL)
         {
-            pr_err("wasm: Calling filter %s.proxy_on_delete errored %s\n", f->name, result.err);
+            pr_err("wasm: calling %s.proxy_on_delete errored %s", f->name, result.err);
         }
     }
 

--- a/socket.c
+++ b/socket.c
@@ -242,7 +242,9 @@ static void free_wasm_socket_context(wasm_socket_context *sc)
 	{
 		printk("free_wasm_socket_context: shutting down wasm_socket_context of context id: %p", sc->pc);
 
+		proxywasm_lock(sc->p);
 		proxywasm_destroy_context(sc->p);
+		proxywasm_unlock(sc->p);
 
 		// TODO we should call br_sslio_close here, but that hangs in non-typed socket mode
 		br_ssl_engine_close(sc->ioc.engine);
@@ -270,7 +272,6 @@ static void free_wasm_socket_context(wasm_socket_context *sc)
 		kfree(sc->rsa_pub);
 		kfree(sc->cert);
 
-		// TODO free the proxywasm context
 		kfree(sc);
 	}
 }

--- a/socket.c
+++ b/socket.c
@@ -243,6 +243,7 @@ static void free_wasm_socket_context(wasm_socket_context *sc)
 		printk("free_wasm_socket_context: shutting down wasm_socket_context of context id: %p", sc->pc);
 
 		proxywasm_lock(sc->p);
+		proxywasm_set_context(sc->p, sc->pc);
 		proxywasm_destroy_context(sc->p);
 		proxywasm_unlock(sc->p);
 


### PR DESCRIPTION
## Description

This caused nasty issues during socket close.

Also updating the tcp metadata filter from nasp to the current version.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
