### PR TITLE
proxywasm: opa based connection eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 cli/cli
 target/
 linux/
+*_wasm.h

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,19 @@ wasm-objs :=  third-party/wasm3/source/m3_api_libc.o \
 
 # Set the path to the Kernel build utils.
 KBUILD=/lib/modules/$(shell uname -r)/build/
- 
-default:
+
+default: socket_wasm.h
 	cd third-party/BearSSL && $(MAKE) linux-km
 	$(MAKE) -C $(KBUILD) M=$(PWD) V=$(VERBOSE) modules
+
+socket_wasm.h: socket.rego
+	opa build -t wasm -e "socket/allow" socket.rego -o bundle.tar.gz
+	tar zxvf bundle.tar.gz /policy.wasm
+	mv policy.wasm socket.wasm
+	xxd -i socket.wasm socket_wasm.h
+
+opa-test:
+	opa test *.rego -v
 
 clean:
 	$(MAKE) -C $(KBUILD) M=$(PWD) clean

--- a/device_driver.c
+++ b/device_driver.c
@@ -308,8 +308,9 @@ wasm_vm_result load_module(char *name, char *code, unsigned length, char *entryp
             result.err = NULL;
         }
 
-        if (strcmp(name, OPA_MODULE) == 0)
+        if (strstr(name, OPA_MODULE) != NULL)
         {
+            printk("wasm: initializing opa for %s", name);
             result = init_opa_for(vm, module);
             if (result.err)
             {

--- a/main.c
+++ b/main.c
@@ -24,8 +24,9 @@
 #include "socket.h"
 
 #include "filter_stats.h"
-#include "module_csr.h"
 #include "filter_tcp_metadata.h"
+#include "module_csr.h"
+#include "socket_wasm.h"
 
 MODULE_AUTHOR("Cisco Systems");
 MODULE_LICENSE("Dual MIT/GPL");
@@ -103,7 +104,14 @@ static int __init wasm_init(void)
         result = load_module("csr_module", module_csr, size_module_csr, NULL);
         if (result.err)
         {
-            FATAL("load_module -> csr_gen_filter: %s", result.err);
+            FATAL("load_module -> csr_module: %s", result.err);
+            return -1;
+        }
+
+        result = load_module("socket_opa", socket_wasm, socket_wasm_len, NULL);
+        if (result.err)
+        {
+            FATAL("load_module -> socket_opa: %s", result.err);
             return -1;
         }
     }

--- a/opa.c
+++ b/opa.c
@@ -232,6 +232,8 @@ wasm_vm_result init_opa_for(wasm_vm *vm, wasm_vm_module *module)
     wasm_vm_try_get_function(builtinsFunc, wasm_vm_get_function(vm, OPA_MODULE, "builtins"));
     opa->vm = vm;
 
+    printk("got all functions");
+
     result = wasm_vm_call_direct(vm, builtinsFunc);
     if (result.err)
         goto error;
@@ -282,7 +284,7 @@ int this_cpu_opa_eval(const char *input)
 {
     int ret = false;
     i32 inputAddr = 0;
-    i32 inputLen = strlen(input) + 1;
+    i32 inputLen = strlen(input);
     wasm_vm_result result;
 
     wasm_vm *vm = this_cpu_wasm_vm();

--- a/opa.c
+++ b/opa.c
@@ -224,12 +224,12 @@ wasm_vm_result init_opa_for(wasm_vm *vm, wasm_vm_module *module)
     wasm_vm_function *builtinsFunc;
 
     opa_wrapper *opa = kmalloc(sizeof(struct opa_wrapper), GFP_KERNEL);
-    wasm_vm_try_get_function(opa->malloc, wasm_vm_get_function(vm, OPA_MODULE, "opa_malloc"));
-    wasm_vm_try_get_function(opa->free, wasm_vm_get_function(vm, OPA_MODULE, "opa_free"));
-    wasm_vm_try_get_function(opa->eval, wasm_vm_get_function(vm, OPA_MODULE, "opa_eval"));
-    wasm_vm_try_get_function(opa->json_dump, wasm_vm_get_function(vm, OPA_MODULE, "opa_json_dump"));
-    wasm_vm_try_get_function(opa->value_dump, wasm_vm_get_function(vm, OPA_MODULE, "opa_value_dump"));
-    wasm_vm_try_get_function(builtinsFunc, wasm_vm_get_function(vm, OPA_MODULE, "builtins"));
+    wasm_vm_try_get_function(opa->malloc, wasm_vm_get_function(vm, module->name, "opa_malloc"));
+    wasm_vm_try_get_function(opa->free, wasm_vm_get_function(vm, module->name, "opa_free"));
+    wasm_vm_try_get_function(opa->eval, wasm_vm_get_function(vm, module->name, "opa_eval"));
+    wasm_vm_try_get_function(opa->json_dump, wasm_vm_get_function(vm, module->name, "opa_json_dump"));
+    wasm_vm_try_get_function(opa->value_dump, wasm_vm_get_function(vm, module->name, "opa_value_dump"));
+    wasm_vm_try_get_function(builtinsFunc, wasm_vm_get_function(vm, module->name, "builtins"));
     opa->vm = vm;
 
     printk("got all functions");
@@ -275,7 +275,7 @@ wasm_vm_result opa_eval(opa_wrapper *opa, i32 inputAddr, i32 inputLen)
     i32 entrypoint = 0;
     i32 dataAddr = 0;
     i32 heapAddr = 0;
-    i32 format = 0;
+    i32 format = 0; // 0 is JSON, 1 is “value”, i.e. serialized Rego values
 
     return wasm_vm_call_direct(opa->vm, opa->eval, 0, entrypoint, dataAddr, inputAddr, inputLen, heapAddr, format);
 }
@@ -284,7 +284,7 @@ int this_cpu_opa_eval(const char *input)
 {
     int ret = false;
     i32 inputAddr = 0;
-    i32 inputLen = strlen(input);
+    i32 inputLen = strlen(input) + 1;
     wasm_vm_result result;
 
     wasm_vm *vm = this_cpu_wasm_vm();

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -163,9 +163,10 @@ proxywasm *this_cpu_proxywasm(void)
     return proxywasms[cpu];
 }
 
-void proxywasm_lock(proxywasm *p)
+void proxywasm_lock(proxywasm *p, proxywasm_context *c)
 {
     wasm_vm_lock(p->vm);
+    proxywasm_set_context(p, c);
 }
 
 void proxywasm_unlock(proxywasm *p)
@@ -187,7 +188,7 @@ m3ApiRawFunction(proxy_log)
 {
     m3ApiReturnType(i32)
 
-        m3ApiGetArg(i32, log_level);
+    m3ApiGetArg(i32, log_level);
     m3ApiGetArgMem(char *, message_data);
     m3ApiGetArg(i32, message_size);
 

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -83,7 +83,7 @@ typedef struct proxywasm_filter proxywasm_filter;
 
 proxywasm *proxywasm_for_vm(wasm_vm *vm);
 proxywasm *this_cpu_proxywasm(void);
-void proxywasm_lock(proxywasm *p);
+void proxywasm_lock(proxywasm *p, proxywasm_context *c);
 void proxywasm_unlock(proxywasm *p);
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module);

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -22,10 +22,7 @@ static br_hmac_drbg_context hmac_drbg_ctx;
 // Initialize BearSSL random number generator with a unix getrandom backed seeder
 int init_rnd_gen()
 {
-
-    br_prng_seeder seeder;
-
-    seeder = br_prng_seeder_system(NULL);
+    br_prng_seeder seeder = br_prng_seeder_system(NULL);
 
     br_hmac_drbg_init(&hmac_drbg_ctx, &br_sha256_vtable, NULL, 0);
     if (!seeder(&hmac_drbg_ctx.vtable))

--- a/socket.c
+++ b/socket.c
@@ -22,6 +22,7 @@
 #include "csr.h"
 #include "socket.h"
 #include "rsa_tools.h"
+#include "opa.h"
 
 #define RSA_OR_EC 0
 
@@ -601,10 +602,12 @@ typedef enum
 	OUTPUT
 } direction;
 
-// a function to evaluate the connection if it should be intercepted
-bool eval_connection(u16 port, direction direction, const char *comm)
+// a function to evaluate the connection if it should be intercepted, now with opa
+bool eval_connection(u16 port, direction direction, const char *command)
 {
-	return (port == 8000 || port == 8080); //&& direction == INPUT && strcmp(comm, "python3") == 0;
+	char input[256];
+	sprintf(input, "{\"port\": %d, \"direction\": %d, \"command\": \"%s\"}", port, direction, command);
+	return this_cpu_opa_eval(input);
 }
 
 struct sock *(*accept)(struct sock *sk, int flags, int *err, bool kern);

--- a/socket.c
+++ b/socket.c
@@ -242,8 +242,7 @@ static void free_wasm_socket_context(wasm_socket_context *sc)
 	{
 		printk("free_wasm_socket_context: shutting down wasm_socket_context of context id: %p", sc->pc);
 
-		proxywasm_lock(sc->p);
-		proxywasm_set_context(sc->p, sc->pc);
+		proxywasm_lock(sc->p, sc->pc);
 		proxywasm_destroy_context(sc->p);
 		proxywasm_unlock(sc->p);
 
@@ -445,8 +444,7 @@ int wasm_recvmsg(struct sock *sock,
 
 	set_read_buffer_size(c, get_read_buffer_size(c) + ret);
 
-	proxywasm_lock(c->p);
-	proxywasm_set_context(c->p, c->pc);
+	proxywasm_lock(c->p, c->pc);
 	wasm_vm_result result;
 	switch (c->direction)
 	{
@@ -528,8 +526,7 @@ int wasm_sendmsg(struct sock *sock, struct msghdr *msg, size_t size)
 
 	set_write_buffer_size(c, get_write_buffer_size(c) + len);
 
-	proxywasm_lock(c->p);
-	proxywasm_set_context(c->p, c->pc);
+	proxywasm_lock(c->p, c->pc);
 	wasm_vm_result result;
 	switch (c->direction)
 	{
@@ -624,7 +621,7 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 	if (client && eval_connection(port, INPUT, current->comm))
 	{
 		proxywasm *p = this_cpu_proxywasm();
-		proxywasm_lock(p);
+		proxywasm_lock(p, NULL);
 
 		wasm_socket_context *sc = new_server_wasm_socket_context(p);
 
@@ -794,7 +791,7 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 		const char *server_name = NULL; // TODO, this needs to be sourced down here
 
 		proxywasm *p = this_cpu_proxywasm();
-		proxywasm_lock(p);
+		proxywasm_lock(p, NULL);
 
 		wasm_socket_context *sc = new_client_wasm_socket_context(p);
 

--- a/socket.rego
+++ b/socket.rego
@@ -8,6 +8,10 @@ package socket
 #   "direction": 0
 # }
 
+# direction constants
+INPUT := 0
+OUTPUT := 1
+
 allowed_ports := {8000, 8080}
 allowed_commands := {"curl", "python3"}
 

--- a/socket.rego
+++ b/socket.rego
@@ -1,11 +1,17 @@
 package socket
 
-allowed_ports := {8000, 8080}
+# the scheme of the input object is the following:
+# {
+#   "port": 8000,
+#   "command": "curl",
+#   "uid": 501,
+#   "direction": 0
+# }
 
+allowed_ports := {8000, 8080}
 allowed_commands := {"curl", "python3"}
 
 allow {
 	allowed_ports[input.port]
-
 	allowed_commands[input.command]
 }

--- a/socket.rego
+++ b/socket.rego
@@ -1,0 +1,11 @@
+package socket
+
+allowed_ports := {8000, 8080}
+
+allowed_commands := {"curl", "python3"}
+
+allow {
+	allowed_ports[input.port]
+
+	allowed_commands[input.command]
+}


### PR DESCRIPTION
## Description

This PR adds the capability to evaluate connections based on [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policies, if they should be intercepted by the Wasm based protocol filter engine.

```rego
package socket

allowed_ports := {8000, 8080}
allowed_commands := {"curl", "python3"}

allow {
	allowed_ports[input.port]
	allowed_commands[input.command]
}
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
