### PR TITLE
don't use stack values in command wait

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -702,6 +702,12 @@ struct sock *wasm_accept(struct sock *sk, int flags, int *err, bool kern)
 			}
 
 			wasm_vm_result generated_csr = csr_gen(csr, addr, len);
+			if (generated_csr.err)
+			{
+				pr_err("wasm_accept: wasm_vm_csr_gen error: %s", generated_csr.err);
+				csr_unlock(csr);
+				return -1;
+			}
 
 			wasm_vm_result free_result = csr_free(csr, addr);
 			if (free_result.err)
@@ -851,6 +857,12 @@ int wasm_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 			}
 
 			wasm_vm_result generated_csr = csr_gen(csr, addr, len);
+			if (generated_csr.err)
+			{
+				pr_err("wasm_connect: wasm_vm_csr_gen error: %s", generated_csr.err);
+				csr_unlock(csr);
+				return -1;
+			}
 
 			wasm_vm_result free_result = csr_free(csr, addr);
 			if (free_result.err)


### PR DESCRIPTION
## Description

It causes freezes on x86 and it isn't a good idea in general.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
