### PR TITLE
opa: make mTLS optional via opa contexts

### DIFF
--- a/opa.h
+++ b/opa.h
@@ -15,8 +15,15 @@
 
 #define OPA_MODULE "opa"
 
+typedef struct {
+    bool allowed;
+    bool mtls;
+    bool permissive;
+} opa_socket_context;
+
 wasm_vm_result init_opa_for(wasm_vm *vm, wasm_vm_module *module);
 
 int this_cpu_opa_eval(const char *input);
+opa_socket_context this_cpu_opa_socket_eval(const char *input);
 
 #endif

--- a/socket.rego
+++ b/socket.rego
@@ -15,7 +15,10 @@ OUTPUT := 1
 allowed_ports := {8000, 8080}
 allowed_commands := {"curl", "python3"}
 
-allow {
+allow = {
+	"mtls": true,
+	"permissive": false,
+} {
 	allowed_ports[input.port]
 	allowed_commands[input.command]
 }

--- a/third-party/parson/json.c
+++ b/third-party/parson/json.c
@@ -86,7 +86,7 @@ static void* malloc(size_t size) {
     return kmalloc(size, GFP_KERNEL);
 }
 
-static void free(void* ptr){
+static void free(void* ptr) {
     kfree(ptr);
 }
 


### PR DESCRIPTION
## Description

OPA socket evaluation policies can return a complex object from now on and it is parsed by the socket.c evaluations in accept/connect, thus enabling us to turn mTLS on/off through it.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
