### PR TITLE
Implement Continue and Pause for wasm filters

### DIFF
--- a/proxywasm.c
+++ b/proxywasm.c
@@ -756,6 +756,11 @@ char *pw_get_upstream_buffer(proxywasm_context *p)
     return p->upstream_buffer;
 }
 
+void pw_set_upstream_buffer(proxywasm_context *p, char *new_buffer)
+{
+    p->upstream_buffer = new_buffer;
+}
+
 int pw_get_upstream_buffer_size(proxywasm_context *p)
 {
     return p->upstream_buffer_size;
@@ -771,9 +776,18 @@ int pw_get_upstream_buffer_capacity(proxywasm_context *p)
     return p->upstream_buffer_capacity;
 }
 
+void pw_set_upstream_buffer_capacity(proxywasm_context *p, int capacity)
+{
+    p->upstream_buffer_capacity = capacity;
+}
+
 char *pw_get_downstream_buffer(proxywasm_context *p)
 {
     return p->downstream_buffer;
+}
+void pw_set_downstream_buffer(proxywasm_context *p, char *new_buffer)
+{
+    p->downstream_buffer = new_buffer;
 }
 
 int pw_get_downstream_buffer_size(proxywasm_context *p)
@@ -789,4 +803,9 @@ void pw_set_downstream_buffer_size(proxywasm_context *p, int size)
 int pw_get_downstream_buffer_capacity(proxywasm_context *p)
 {
     return p->downstream_buffer_capacity;
+}
+
+void pw_set_downstream_buffer_capacity(proxywasm_context *p, int capacity)
+{
+    p->downstream_buffer_capacity = capacity;
 }

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -163,6 +163,11 @@ proxywasm *this_cpu_proxywasm(void)
     return proxywasms[cpu];
 }
 
+static void proxywasm_set_context(proxywasm *p, proxywasm_context *context)
+{
+    p->current_context = context;
+}
+
 void proxywasm_lock(proxywasm *p, proxywasm_context *c)
 {
     wasm_vm_lock(p->vm);
@@ -177,11 +182,6 @@ void proxywasm_unlock(proxywasm *p)
 proxywasm_context *proxywasm_get_context(proxywasm *p)
 {
     return p->current_context;
-}
-
-void proxywasm_set_context(proxywasm *p, proxywasm_context *context)
-{
-    p->current_context = context;
 }
 
 m3ApiRawFunction(proxy_log)

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -112,13 +112,17 @@ void get_buffer_bytes(proxywasm_context *p, BufferType buffer_type, i32 start, i
 WasmResult set_buffer_bytes(proxywasm_context *p, BufferType buffer_type, i32 start, i32 size, char *value, i32 value_len);
 
 char *pw_get_upstream_buffer(proxywasm_context *p);
+void pw_set_upstream_buffer(proxywasm_context *p, char *new_buffer);
 int pw_get_upstream_buffer_size(proxywasm_context *p);
 void pw_set_upstream_buffer_size(proxywasm_context *p, int size);
 int pw_get_upstream_buffer_capacity(proxywasm_context *p);
+void pw_set_upstream_buffer_capacity(proxywasm_context *p, int capacity);
 
 char *pw_get_downstream_buffer(proxywasm_context *p);
+void pw_set_downstream_buffer(proxywasm_context *p, char *new_buffer);
 int pw_get_downstream_buffer_size(proxywasm_context *p);
 void pw_set_downstream_buffer_size(proxywasm_context *p, int size);
 int pw_get_downstream_buffer_capacity(proxywasm_context *p);
+void pw_set_downstream_buffer_capacity(proxywasm_context *p, int capacity);
 
 #endif

--- a/proxywasm.h
+++ b/proxywasm.h
@@ -99,7 +99,6 @@ wasm_vm_result proxywasm_create_context(proxywasm *p);
 wasm_vm_result proxywasm_destroy_context(proxywasm *p);
 
 proxywasm_context *proxywasm_get_context(proxywasm *p);
-void proxywasm_set_context(proxywasm *p, proxywasm_context *context);
 
 // set_property_v is convenience funtion for setting a property on a context, with simple C string paths,
 // use the '.' as delimiter, those will be replaced to a '0' delimiter

--- a/socket.c
+++ b/socket.c
@@ -556,9 +556,7 @@ int wasm_recvmsg(struct sock *sock,
 			goto bail;
 		}
 
-		// 0 means Action::Continue
-		// 1 means Action::Pause
-		if (result.data->i32 == 0 || end_of_stream)
+		if (result.data->i32 == Continue || end_of_stream)
 		{
 			done = true;
 		}
@@ -649,9 +647,7 @@ int wasm_sendmsg(struct sock *sock, struct msghdr *msg, size_t size)
 		goto bail;
 	}
 
-	// 0 means Action::Continue
-	// 1 means Action::Pause
-	if (result.data->i32 == 1)
+	if (result.data->i32 == Pause)
 	{
 		ret = len;
 		goto bail;


### PR DESCRIPTION
## Description
This PR adds the ability to the wasm filters to work with Action::Continue and Action::Pause.
It also reallocates the write and read buffers if it is not big enough.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

Fixes #26 
