### PR TITLE
Allow to add csr parameters

### DIFF
--- a/csr.h
+++ b/csr.h
@@ -13,11 +13,22 @@
 #define CSR_MODULE "csr"
 
 typedef struct csr_module csr_module;
+typedef struct csr_parameters
+{
+    char* subject;
+    char* dns;
+    char* uri;
+    char* email;
+    char* ip;
+
+} csr_parameters;
 
 csr_module *this_cpu_csr(void);
 
 wasm_vm_result init_csr_for(wasm_vm *vm, wasm_vm_module *module);
-wasm_vm_result csr_gen(csr_module *csr, i32 priv_key_buff_ptr, i32 priv_key_buff_len);
+wasm_vm_result csr_gen(csr_module *csr, 
+    i32 priv_key_buff_ptr, i32 priv_key_buff_len, 
+    csr_parameters *parameters);
 wasm_vm_result csr_malloc(csr_module *csr, i32 size);
 wasm_vm_result csr_free(csr_module *csr, i32 ptr);
 wasm_vm_module *get_csr_module(csr_module *csr);


### PR DESCRIPTION
## Description
This PR allows to add Certificate Signing Request parameters. Now the values are hardcoded but can be replaced easily.
## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

Fixes #53 

## TODO

- [ ] Refactor wasm_accept and wasm_connect functions to avoid duplications.
